### PR TITLE
회원별 회원가입, 로그인, 토큰 재발급 기능 추가

### DIFF
--- a/precending/src/main/java/umc/precending/PrecendingApplication.java
+++ b/precending/src/main/java/umc/precending/PrecendingApplication.java
@@ -2,8 +2,10 @@ package umc.precending;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PrecendingApplication {
 
 	public static void main(String[] args) {

--- a/precending/src/main/java/umc/precending/advice/ExceptionAdvice.java
+++ b/precending/src/main/java/umc/precending/advice/ExceptionAdvice.java
@@ -1,0 +1,46 @@
+package umc.precending.advice;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import umc.precending.exception.member.MemberDuplicateException;
+import umc.precending.exception.member.MemberLoginFailureException;
+import umc.precending.exception.member.MemberNotFoundException;
+import umc.precending.exception.token.TokenNotCorrectException;
+import umc.precending.response.Response;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return Response.failure(400, e.getBindingResult().getFieldError().getDefaultMessage());
+    }
+
+    @ExceptionHandler(MemberNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Response memberNotFoundException() {
+        return Response.failure(404, "조건에 부합하는 회원을 찾지 못하였습니다.");
+    }
+
+    @ExceptionHandler(MemberDuplicateException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Response memberDuplicateException() {
+        return Response.failure(409, "입력한 정보로 가입된 사용자가 존재합니다.");
+    }
+
+    @ExceptionHandler(MemberLoginFailureException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response memberLoginFailureException() {
+        return Response.failure(400, "아이디 혹은 비밀번호가 일치하지 않습니다. 다시 한 번 확인해주세요.");
+    }
+
+    @ExceptionHandler(TokenNotCorrectException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response tokenNotCorrectException() {
+        return Response.failure(400, "저장된 토큰의 정보와 일치하지 않습니다.");
+    }
+}

--- a/precending/src/main/java/umc/precending/config/CorsConfig.java
+++ b/precending/src/main/java/umc/precending/config/CorsConfig.java
@@ -1,0 +1,27 @@
+package umc.precending.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration cors = new CorsConfiguration();
+
+        cors.addAllowedOrigin("http://localhost:3000");
+        cors.addAllowedHeader("*");
+        cors.addAllowedMethod("*");
+        cors.setAllowCredentials(true);
+        cors.setMaxAge(3600L);
+
+        source.registerCorsConfiguration("/**", cors);
+
+        return new CorsFilter(source);
+    }
+}

--- a/precending/src/main/java/umc/precending/config/RedisConfig.java
+++ b/precending/src/main/java/umc/precending/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package umc.precending.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String hostname;
+
+    @Value("${spring.redis.password}")
+    private String password;
+
+    @Value("${spring.redis.port}")
+    private Integer portNumber;
+
+    @Bean
+    public LettuceConnectionFactory connectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(hostname);
+        configuration.setPassword(password);
+        configuration.setPort(portNumber);
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, String> template() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setConnectionFactory(connectionFactory());
+        return template;
+    }
+}

--- a/precending/src/main/java/umc/precending/config/SecurityConfig.java
+++ b/precending/src/main/java/umc/precending/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package umc.precending.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import umc.precending.config.jwt.*;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationEntryPointHandler authenticationEntryPointHandler;
+    private final JwtAccessDeniedHandler accessDeniedHandler;
+    private final TokenProvider tokenProvider;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain configure(HttpSecurity http) throws Exception {
+        return http
+                .csrf().disable()
+                .formLogin().disable()
+
+                .exceptionHandling()
+                .authenticationEntryPoint(authenticationEntryPointHandler)
+                .accessDeniedHandler(accessDeniedHandler)
+
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                .and()
+                .apply(new JwtSecurityConfig(tokenProvider))
+
+                .and().build();
+    }
+}

--- a/precending/src/main/java/umc/precending/config/SwaggerConfig.java
+++ b/precending/src/main/java/umc/precending/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package umc.precending.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    private final String title = "선행의 모든 것";
+    private final String description = "UMC4기 프로젝트 '선행의 모든 것' 제작을 위한 협업 툴입니다.";
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("umc.precending.controller"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+    public ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title(title)
+                .description(description)
+                .build();
+
+    }
+}

--- a/precending/src/main/java/umc/precending/config/WebConfig.java
+++ b/precending/src/main/java/umc/precending/config/WebConfig.java
@@ -1,0 +1,24 @@
+package umc.precending.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+@EnableWebMvc
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000");
+    }
+
+    @Bean
+    public InternalResourceViewResolver defaultViewResolver() {
+        return new InternalResourceViewResolver();
+    }
+}

--- a/precending/src/main/java/umc/precending/config/jwt/JwtAccessDeniedHandler.java
+++ b/precending/src/main/java/umc/precending/config/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package umc.precending.config.jwt;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/precending/src/main/java/umc/precending/config/jwt/JwtAuthenticationEntryPointHandler.java
+++ b/precending/src/main/java/umc/precending/config/jwt/JwtAuthenticationEntryPointHandler.java
@@ -1,0 +1,19 @@
+package umc.precending.config.jwt;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/precending/src/main/java/umc/precending/config/jwt/JwtFilter.java
+++ b/precending/src/main/java/umc/precending/config/jwt/JwtFilter.java
@@ -1,0 +1,43 @@
+package umc.precending.config.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final String AUTHORIZATION_KEY = "Authorization";
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String tokenValue = parseHeader(request);
+
+        if(StringUtils.hasText(tokenValue) && tokenProvider.validateToken(tokenValue)) {
+            Authentication authentication = tokenProvider.getAuthentication(tokenValue);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    public String parseHeader(HttpServletRequest request) {
+        String token = request.getHeader(AUTHORIZATION_KEY);
+
+        if(StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return null;
+    }
+}

--- a/precending/src/main/java/umc/precending/config/jwt/JwtSecurityConfig.java
+++ b/precending/src/main/java/umc/precending/config/jwt/JwtSecurityConfig.java
@@ -1,0 +1,18 @@
+package umc.precending.config.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void configure(HttpSecurity http) {
+        http.addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/precending/src/main/java/umc/precending/config/jwt/JwtUserDetailsService.java
+++ b/precending/src/main/java/umc/precending/config/jwt/JwtUserDetailsService.java
@@ -1,0 +1,34 @@
+package umc.precending.config.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import umc.precending.domain.member.Member;
+import umc.precending.exception.member.MemberNotFoundException;
+import umc.precending.repository.member.MemberRepository;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class JwtUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return memberRepository.findMemberByUsername(username)
+                .map(this::getUserDetails)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
+    public UserDetails getUserDetails(Member member) {
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(member.getAuthority().toString());
+
+        return new User(member.getUsername(), member.getPassword(), Collections.singleton(authority));
+    }
+}

--- a/precending/src/main/java/umc/precending/config/jwt/TokenProvider.java
+++ b/precending/src/main/java/umc/precending/config/jwt/TokenProvider.java
@@ -1,0 +1,111 @@
+package umc.precending.config.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import umc.precending.dto.token.TokenDto;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class TokenProvider implements InitializingBean {
+
+    private final static String AUTHORIZATION_KEY = "auth";
+    private final Long validationTime;
+    private final Long refreshTokenValidationTime;
+    private final String secret;
+    private Key key;
+
+    public TokenProvider(@Value("${jwt.secret}") String secret,
+                         @Value("${jwt.validationTime}") Long validationTime) {
+        this.secret = secret;
+        this.validationTime = validationTime * 1000;
+        this.refreshTokenValidationTime = validationTime * 2 * 1000;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] key_set = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(key_set);
+    }
+
+    // Authentication 객체를 통하여 토큰 생성
+    public TokenDto createToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities()
+                .stream().map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        String accessToken = Jwts.builder()
+                .setExpiration(new Date(now + validationTime))
+                .setSubject(authentication.getName())
+                .claim(AUTHORIZATION_KEY, authorities)
+                .signWith(this.key, SignatureAlgorithm.HS512)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + refreshTokenValidationTime))
+                .signWith(this.key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .validationTime(validationTime)
+                .type("Bearer ")
+                .build();
+    }
+
+    // 토큰을 통하여 Authentication 객체 생성
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseData(token).getBody();
+
+        List<SimpleGrantedAuthority> authorities = Arrays
+                .stream(claims.get(AUTHORIZATION_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            parseData(token);
+            return true;
+        } catch(MalformedJwtException | SecurityException e) {
+            log.info("잘못된 형식의 토큰입니다.");
+        } catch(ExpiredJwtException e) {
+            log.info("만료된 토큰입니다.");
+        } catch(UnsupportedJwtException e) {
+            log.info("지원하지 않는 형식의 토큰입니다.");
+        } catch(IllegalArgumentException e) {
+            log.info("잘못된 토큰입니다.");
+        }
+        return false;
+    }
+
+    public Jws<Claims> parseData(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(this.key)
+                .build().parseClaimsJws(token);
+    }
+}

--- a/precending/src/main/java/umc/precending/controller/auth/AuthController.java
+++ b/precending/src/main/java/umc/precending/controller/auth/AuthController.java
@@ -1,0 +1,61 @@
+package umc.precending.controller.auth;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import umc.precending.dto.auth.*;
+import umc.precending.dto.token.TokenRequestDto;
+import umc.precending.response.Response;
+import umc.precending.service.auth.AuthService;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/auth/sign-up/person")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "회원가입 - 개인", notes = "개인 회원으로 가입하기 위한 로직")
+    @ApiImplicitParam(name = "signUpDto", value = "회원가입을 위한 데이터가 담겨진 DTO")
+    public void signUp(@RequestBody @Valid MemberPersonSignUpDto signUpDto) {
+        authService.signUp(signUpDto);
+    }
+
+    @PostMapping("/auth/sign-up/corporate")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "회원가입 - 기업", notes = "단체 회원 - 기업으로 가입하기 위한 로직")
+    @ApiImplicitParam(name = "signUpDto", value = "회원가입을 위한 데이터가 담겨진 DTO")
+    public void signUp(@RequestBody @Valid MemberCorporateSignUpDto signUpDto) {
+        authService.signUp(signUpDto);
+    }
+
+    @PostMapping("/auth/sign-up/club")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "회원가입 - 동아리", notes = "단체 회원 - 동아리로 가입하기 위한 로직")
+    @ApiImplicitParam(name = "signUpDto", value = "회원가입을 위한 데이터가 담겨진 DTO")
+    public void signUp(@RequestBody @Valid MemberClubSignUpDto signUpDto) {
+        authService.signUp(signUpDto);
+    }
+
+    @PostMapping("/auth/sign-in")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "로그인", notes = "로그인하기 위한 로직")
+    @ApiImplicitParam(name = "signInDto", value = "로그인을 위한 데이터가 담겨진 DTO")
+    public Response signIn(@RequestBody @Valid MemberSignInDto signInDto) {
+        return Response.success(authService.signIn(signInDto));
+    }
+
+    @PostMapping("/auth/reissue")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "토큰 재발급", notes = "만료 기간이 완료된 토큰을 재발급하는 로직")
+    @ApiImplicitParam(name = "requestDto", value = "토큰 재발급에 필요한 정보들이 담긴 DTO")
+    public Response reIssue(@RequestBody @Valid TokenRequestDto requestDto) {
+        return Response.success(authService.reIssue(requestDto));
+    }
+}

--- a/precending/src/main/java/umc/precending/domain/base/BaseEntity.java
+++ b/precending/src/main/java/umc/precending/domain/base/BaseEntity.java
@@ -1,0 +1,25 @@
+package umc.precending.domain.base;
+
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(value = AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime firstCreatedDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/precending/src/main/java/umc/precending/domain/member/Authority.java
+++ b/precending/src/main/java/umc/precending/domain/member/Authority.java
@@ -1,0 +1,8 @@
+package umc.precending.domain.member;
+
+import lombok.Getter;
+
+@Getter
+public enum Authority {
+    ROLE_PERSON, ROLE_CORPORATE, ROLE_CLUB
+}

--- a/precending/src/main/java/umc/precending/domain/member/Club.java
+++ b/precending/src/main/java/umc/precending/domain/member/Club.java
@@ -1,0 +1,40 @@
+package umc.precending.domain.member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Club extends Member {
+
+    @Column(name = "school", nullable = false)
+    private String school; // 동아리가 속해있는 학교
+
+    @Column(name = "address", nullable = false)
+    private String address; // 동아리 주소
+
+    @Column(name = "clubType", nullable = false)
+    private String type; // 동아리 유형
+
+    public Club(String name, String birth, String password,
+                String email, String type, String school, String address) {
+        this.name = name;
+        this.username = email;
+        this.birth = birth;
+        this.password = password;
+        this.email = email;
+        this.emailValidation = false;
+        this.introduction = "";
+        this.authority = Authority.ROLE_CLUB;
+        this.school = school;
+        this.address = address;
+        this.type = type;
+    }
+}

--- a/precending/src/main/java/umc/precending/domain/member/Corporate.java
+++ b/precending/src/main/java/umc/precending/domain/member/Corporate.java
@@ -1,0 +1,31 @@
+package umc.precending.domain.member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Corporate extends Member {
+    @Column(name = "registrationNumber", nullable = false, unique = true)
+    private String registrationNumber; // 사업자 등록 번호
+
+    public Corporate(String name, String birth, String password,
+                     String email, String registrationNumber) {
+        this.name = name;
+        this.username = email;
+        this.birth = birth;
+        this.password = password;
+        this.email = email;
+        this.emailValidation = false;
+        this.introduction = "";
+        this.registrationNumber = registrationNumber;
+        this.authority = Authority.ROLE_CORPORATE;
+    }
+}

--- a/precending/src/main/java/umc/precending/domain/member/Member.java
+++ b/precending/src/main/java/umc/precending/domain/member/Member.java
@@ -1,0 +1,45 @@
+package umc.precending.domain.member;
+
+import lombok.*;
+import umc.precending.domain.base.BaseEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Table(name = "member")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorColumn
+@Inheritance(strategy = InheritanceType.JOINED)
+public abstract class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    protected Long id;
+
+    @Column(name = "name", nullable = false)
+    protected String name; // 개인, 동아리, 기업의 이름
+
+    @Column(name = "username", nullable = false)
+    protected String username; // 사용자의 아이디
+
+    @Column(name = "birth", nullable = false)
+    protected String birth; // 출생/설립 연도
+
+    @Column(name = "password", nullable = false)
+    protected String password; // 비밀번호
+
+    @Column(name = "email", nullable = false, unique = true)
+    protected String email; // 이메일
+
+    @Column(name = "emailValidation", nullable = false)
+    protected boolean emailValidation; // 이메일 인증 여부
+
+    @Column(name = "introduction", nullable = false)
+    @Lob
+    protected String introduction; // 프로필 화면에서 노출시킬 소개글
+
+    @Enumerated(value = EnumType.STRING)
+    protected Authority authority; // 사용자가 어떠한 회원인지를 명시(ex) 개인 회원, 동아리 회원, 기업 회원 등)
+}

--- a/precending/src/main/java/umc/precending/domain/member/Person.java
+++ b/precending/src/main/java/umc/precending/domain/member/Person.java
@@ -1,0 +1,35 @@
+package umc.precending.domain.member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Person extends Member{
+    @Column(name = "phone", nullable = false, unique = true)
+    private String phone; // 개인 회원의 핸드폰 번호
+
+    @Column(name = "phoneValidation", nullable = false)
+    private boolean phoneValidation; // 개인 회원의 핸드폰 인증 여부
+
+    public Person(String name, String birth, String password,
+                  String email, String phone) {
+        this.name = name;
+        this.username = email;
+        this.birth = birth;
+        this.password = password;
+        this.email = email;
+        this.emailValidation = false;
+        this.introduction = "";
+        this.phone = phone;
+        this.phoneValidation = false;
+        this.authority = Authority.ROLE_PERSON;
+    }
+}

--- a/precending/src/main/java/umc/precending/dto/auth/MemberClubSignInDto.java
+++ b/precending/src/main/java/umc/precending/dto/auth/MemberClubSignInDto.java
@@ -1,0 +1,29 @@
+package umc.precending.dto.auth;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MemberClubSignInDto {
+    @NotBlank(message = "로그인을 수행하기 위하여 동아리의 이름을 입력해주세요.")
+    @ApiModelProperty(value = "로그인에 필요한 동아리의 이름", example = "test")
+    private String name;
+
+    @NotBlank(message = "로그인을 수행하기 위하여 동아리의 유형을 입력해주세요.")
+    @ApiModelProperty(value = "로그인에 필요한 동아리의 유형", example = "type")
+    private String type;
+
+    @NotBlank(message = "로그인을 수행하기 위하여 학교명을 입력해주세요.")
+    @ApiModelProperty(value = "로그인에 필요한 학교명", example = "test")
+    private String school;
+
+    @NotBlank(message = "로그인을 수행하기 위한 비밀번호를 입력해주세요.")
+    @ApiModelProperty(value = "로그인에 필요한 비밀번호", example = "1234")
+    private String password;
+}

--- a/precending/src/main/java/umc/precending/dto/auth/MemberClubSignUpDto.java
+++ b/precending/src/main/java/umc/precending/dto/auth/MemberClubSignUpDto.java
@@ -1,0 +1,43 @@
+package umc.precending.dto.auth;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MemberClubSignUpDto {
+    @NotBlank(message = "회원가입에 필요한 이름을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 동아리의 이름", name = "test")
+    private String name;
+
+    @NotBlank(message = "회원가입에 필요한 동아리 설립일을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 동아리의 설립일(연도, 월)", name = "9999/12")
+    private String birth;
+
+    @NotBlank(message = "회원가입에 필요한 동아리 유형을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 동아리의 유형", name = "type")
+    private String type;
+
+    @NotBlank(message = "회원가입에 필요한 주소를 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 동아리의 주소", name = "address")
+    private String address;
+
+    @NotBlank(message = "회원가입에 필요한 학교명을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 학교명", name = "school")
+    private String school;
+
+    @NotBlank(message = "회원가입에 필요한 비밀번호를 입력해주세요.")
+    @Length(min = 8, max = 16, message = "비밀번호는 최소 8자, 최대 16자로 구성되어야합니다.")
+    @ApiModelProperty(value = "회웝가입에 필요한 비밀번호", name = "1234")
+    private String password;
+
+    @NotBlank(message = "회원가입에 필요한 이메일을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 이메일", name = "test@test.com")
+    private String email;
+}

--- a/precending/src/main/java/umc/precending/dto/auth/MemberCorporateSignUpDto.java
+++ b/precending/src/main/java/umc/precending/dto/auth/MemberCorporateSignUpDto.java
@@ -1,0 +1,36 @@
+package umc.precending.dto.auth;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MemberCorporateSignUpDto {
+    @NotBlank(message = "회원가입에 필요한 이름을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 기업의 이름", example = "test")
+    private String name;
+
+    @NotBlank(message = "회원가입에 필요한 설립일을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 기업의 설립일(연도, 월)", example = "9999/12")
+    private String birth;
+
+    @NotBlank(message = "회원가입에 필요한 사업자번호를 입력해주세요.")
+    @Length(max = 12)
+    @ApiModelProperty(value = "회원가입에 필요한 사업자 번호", example = "123-45-67890")
+    private String registrationNumber;
+
+    @NotBlank(message = "회원가입에 필요한 비밀번호를 입력해주세요.")
+    @Length(min = 8, max = 16, message = "비밀번호는 최소 8자, 최대 16자로 구성되어야합니다.")
+    @ApiModelProperty(value = "회원가입에 필요한 비밀번호", example = "1234")
+    private String password;
+
+    @NotBlank(message = "회원가입에 필요한 이메일을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 이메일", example = "test@test.com")
+    private String email;
+}

--- a/precending/src/main/java/umc/precending/dto/auth/MemberPersonSignUpDto.java
+++ b/precending/src/main/java/umc/precending/dto/auth/MemberPersonSignUpDto.java
@@ -1,0 +1,35 @@
+package umc.precending.dto.auth;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MemberPersonSignUpDto {
+    @NotBlank(message = "회원가입에 필요한 이름을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 사용자의 이름", example = "test")
+    private String name;
+
+    @NotBlank(message = "회원가입에 필요한 생년월일을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 사용자의 생년월일", example = "99991231")
+    private String birth;
+
+    @NotBlank(message = "회원가입에 필요한 핸드폰 번호를 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 사용자의 핸드폰 번호", example = "010-1234-5678")
+    private String phone;
+
+    @NotBlank(message = "회원가입에 필요한 이메일을 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 사용자의 이메일", example = "test@test.com")
+    private String email;
+
+    @NotBlank(message = "회원가입에 필요한 비밀번호를 입력해주세요.")
+    @ApiModelProperty(value = "회원가입에 필요한 사용자의 비밀번호", example = "1234")
+    @Length(min = 8, max = 16, message = "비밀번호는 최소 8자, 최대 16자로 구성되어야합니다.")
+    private String password;
+}

--- a/precending/src/main/java/umc/precending/dto/auth/MemberSignInDto.java
+++ b/precending/src/main/java/umc/precending/dto/auth/MemberSignInDto.java
@@ -1,0 +1,26 @@
+package umc.precending.dto.auth;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import javax.validation.constraints.NotBlank;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MemberSignInDto {
+    @NotBlank(message = "로그인을 수행하기 위한 아이디를 입력해주세요.")
+    @ApiModelProperty(value = "로그인에 필요한 아이디", example = "test")
+    private String username;
+
+    @NotBlank(message = "로그인을 수행하기 위한 비밀번호를 입력해주세요.")
+    @ApiModelProperty(value = "로그인에 필요한 비밀번호", example = "1234")
+    private String password;
+
+    public UsernamePasswordAuthenticationToken getAuthenticationToken() {
+        return new UsernamePasswordAuthenticationToken(username, password);
+    }
+}

--- a/precending/src/main/java/umc/precending/dto/token/TokenDto.java
+++ b/precending/src/main/java/umc/precending/dto/token/TokenDto.java
@@ -1,0 +1,17 @@
+package umc.precending.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+    private String type;
+    private Long validationTime;
+}

--- a/precending/src/main/java/umc/precending/dto/token/TokenRequestDto.java
+++ b/precending/src/main/java/umc/precending/dto/token/TokenRequestDto.java
@@ -1,0 +1,21 @@
+package umc.precending.dto.token;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class TokenRequestDto {
+    @NotBlank(message = "토큰 재발급을 위하여 accessToken의 값을 입력해주세요.")
+    @ApiModelProperty(value = "accessToken", example = "accessToken")
+    private String accessToken;
+
+    @NotBlank(message = "토큰 재발급을 위하여 refreshToken의 값을 입력해주세요.")
+    @ApiModelProperty(value = "refreshToken", example = "refreshToken")
+    private String refreshToken;
+}

--- a/precending/src/main/java/umc/precending/dto/token/TokenResponseDto.java
+++ b/precending/src/main/java/umc/precending/dto/token/TokenResponseDto.java
@@ -1,0 +1,13 @@
+package umc.precending.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class TokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/precending/src/main/java/umc/precending/exception/member/MemberDuplicateException.java
+++ b/precending/src/main/java/umc/precending/exception/member/MemberDuplicateException.java
@@ -1,0 +1,4 @@
+package umc.precending.exception.member;
+
+public class MemberDuplicateException extends RuntimeException {
+}

--- a/precending/src/main/java/umc/precending/exception/member/MemberLoginFailureException.java
+++ b/precending/src/main/java/umc/precending/exception/member/MemberLoginFailureException.java
@@ -1,0 +1,4 @@
+package umc.precending.exception.member;
+
+public class MemberLoginFailureException extends RuntimeException {
+}

--- a/precending/src/main/java/umc/precending/exception/member/MemberNotFoundException.java
+++ b/precending/src/main/java/umc/precending/exception/member/MemberNotFoundException.java
@@ -1,0 +1,4 @@
+package umc.precending.exception.member;
+
+public class MemberNotFoundException extends RuntimeException {
+}

--- a/precending/src/main/java/umc/precending/exception/token/TokenNotCorrectException.java
+++ b/precending/src/main/java/umc/precending/exception/token/TokenNotCorrectException.java
@@ -1,0 +1,4 @@
+package umc.precending.exception.token;
+
+public class TokenNotCorrectException extends RuntimeException {
+}

--- a/precending/src/main/java/umc/precending/repository/member/ClubRepository.java
+++ b/precending/src/main/java/umc/precending/repository/member/ClubRepository.java
@@ -1,0 +1,7 @@
+package umc.precending.repository.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.precending.domain.member.Club;
+
+public interface ClubRepository extends JpaRepository<Club, Long> {
+}

--- a/precending/src/main/java/umc/precending/repository/member/CorporateRepository.java
+++ b/precending/src/main/java/umc/precending/repository/member/CorporateRepository.java
@@ -1,0 +1,11 @@
+package umc.precending.repository.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.precending.domain.member.Corporate;
+
+import java.util.Optional;
+
+public interface CorporateRepository extends JpaRepository<Corporate, Long> {
+    Optional<Corporate> findCorporateByRegistrationNumber(String registrationNumber);
+    boolean existsCorporateByRegistrationNumber(String registrationNumber);
+}

--- a/precending/src/main/java/umc/precending/repository/member/MemberRepository.java
+++ b/precending/src/main/java/umc/precending/repository/member/MemberRepository.java
@@ -1,0 +1,10 @@
+package umc.precending.repository.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.precending.domain.member.Member;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findMemberByUsername(String username);
+}

--- a/precending/src/main/java/umc/precending/repository/member/PersonRepository.java
+++ b/precending/src/main/java/umc/precending/repository/member/PersonRepository.java
@@ -1,0 +1,11 @@
+package umc.precending.repository.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.precending.domain.member.Person;
+
+import java.util.Optional;
+
+public interface PersonRepository extends JpaRepository<Person, Long> {
+    Optional<Person> findPersonByPhone(String phone);
+    boolean existsPersonByPhone(String phone);
+}

--- a/precending/src/main/java/umc/precending/response/Failure.java
+++ b/precending/src/main/java/umc/precending/response/Failure.java
@@ -1,0 +1,10 @@
+package umc.precending.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Failure implements Result{
+    private String message;
+}

--- a/precending/src/main/java/umc/precending/response/Response.java
+++ b/precending/src/main/java/umc/precending/response/Response.java
@@ -1,0 +1,25 @@
+package umc.precending.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class Response {
+    private int code;
+    private boolean success;
+    private Result result;
+
+    public static Response success() {
+        return new Response(0, true, null);
+    }
+
+    public static <T> Response success(T data) {
+        return new Response(0, true, new Success(data));
+    }
+
+    public static Response failure(int code, String message) {
+        return new Response(code, false, new Failure(message));
+    }
+}

--- a/precending/src/main/java/umc/precending/response/Result.java
+++ b/precending/src/main/java/umc/precending/response/Result.java
@@ -1,0 +1,4 @@
+package umc.precending.response;
+
+public interface Result {
+}

--- a/precending/src/main/java/umc/precending/response/Success.java
+++ b/precending/src/main/java/umc/precending/response/Success.java
@@ -1,0 +1,10 @@
+package umc.precending.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Success<T> implements Result{
+    private T data;
+}

--- a/precending/src/main/java/umc/precending/service/auth/AuthService.java
+++ b/precending/src/main/java/umc/precending/service/auth/AuthService.java
@@ -1,0 +1,129 @@
+package umc.precending.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.precending.config.jwt.TokenProvider;
+import umc.precending.domain.member.Club;
+import umc.precending.domain.member.Corporate;
+import umc.precending.domain.member.Member;
+import umc.precending.domain.member.Person;
+import umc.precending.dto.auth.*;
+import umc.precending.dto.token.TokenDto;
+import umc.precending.dto.token.TokenRequestDto;
+import umc.precending.dto.token.TokenResponseDto;
+import umc.precending.exception.member.MemberDuplicateException;
+import umc.precending.exception.member.MemberLoginFailureException;
+import umc.precending.exception.member.MemberNotFoundException;
+import umc.precending.repository.member.ClubRepository;
+import umc.precending.repository.member.CorporateRepository;
+import umc.precending.repository.member.MemberRepository;
+import umc.precending.repository.member.PersonRepository;
+import umc.precending.service.redis.RedisService;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final PersonRepository personRepository;
+    private final CorporateRepository corporateRepository;
+    private final ClubRepository clubRepository;
+    private final RedisService redisService;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final TokenProvider tokenProvider;
+
+    // 회원가입 - 개인
+    @Transactional
+    public void signUp(MemberPersonSignUpDto signUpDto) {
+        Person personMember = getPersonMember(signUpDto);
+        memberRepository.save(personMember);
+    }
+
+    // 회원가입 - 동아리
+    @Transactional
+    public void signUp(MemberClubSignUpDto signUpDto) {
+        Club clubMember = getClubMember(signUpDto);
+        memberRepository.save(clubMember);
+    }
+
+    //회원가입 - 기업
+    @Transactional
+    public void signUp(MemberCorporateSignUpDto signUpDto) {
+        Corporate corporateMember = getCorporateMember(signUpDto);
+        memberRepository.save(corporateMember);
+    }
+
+    // 로그인
+    @Transactional
+    public TokenResponseDto signIn(MemberSignInDto signInDto) {
+        checkLoginValidation(signInDto);
+
+        UsernamePasswordAuthenticationToken authenticationToken = signInDto.getAuthenticationToken();
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        TokenDto tokenValue = tokenProvider.createToken(authentication);
+        redisService.saveValue(authentication.getName(), tokenValue.getRefreshToken());
+
+        return new TokenResponseDto(tokenValue.getAccessToken(), tokenValue.getRefreshToken());
+    }
+
+    // 만료기간이 다 된 토큰을 재발급받는 로직
+    @Transactional
+    public TokenResponseDto reIssue(TokenRequestDto requestDto) {
+        String accessToken = requestDto.getAccessToken();
+        String refreshToken = requestDto.getRefreshToken();
+
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+
+        redisService.checkValidation(authentication.getName(), refreshToken);
+
+        TokenDto token = tokenProvider.createToken(authentication);
+
+        redisService.saveValue(authentication.getName(), token.getRefreshToken());
+
+        return new TokenResponseDto(token.getAccessToken(), token.getRefreshToken());
+    }
+
+    // 사용자가 로그인을 수행하면서 입력한 정보와 일치하는 계정이 있는지 확인하는 로직
+    private void checkLoginValidation(MemberSignInDto signInDto) {
+        Member findMember = memberRepository.findMemberByUsername(signInDto.getUsername())
+                .orElseThrow(MemberNotFoundException::new);
+
+        if(!checkPwValidation(findMember, signInDto.getPassword())) throw new MemberLoginFailureException();
+    }
+
+    // 비밀번호가 일치하는지 확인하는 로직
+    private boolean checkPwValidation(Member member, String raw) {
+        return passwordEncoder.matches(raw, member.getPassword());
+    }
+
+    // 입력한 정보를 바탕으로 유효성을 검사한 뒤, Person 객체를 반환하는 로직
+    private Person getPersonMember(MemberPersonSignUpDto signUpDto) {
+        if(personRepository.existsPersonByPhone(signUpDto.getPhone())) throw new MemberDuplicateException();
+
+        return new Person(signUpDto.getName(), signUpDto.getBirth(),
+                passwordEncoder.encode(signUpDto.getPassword()), signUpDto.getEmail(), signUpDto.getPhone());
+    }
+
+    // 입력한 정보를 바탕으로 유효성을 검사한 뒤, Club 객체를 반환하는 로직
+    private Club getClubMember(MemberClubSignUpDto signUpDto) {
+        if(clubRepository.existsById(100L)) throw new MemberDuplicateException();
+
+        return new Club(signUpDto.getName(), signUpDto.getBirth(), passwordEncoder.encode(signUpDto.getPassword()),
+                signUpDto.getEmail(), signUpDto.getType(), signUpDto.getSchool(), signUpDto.getAddress());
+    }
+
+    // 입력한 정보를 바탕으로 유효성을 검사한 뒤, Corporate 객체를 반환하는 로직
+    private Corporate getCorporateMember(MemberCorporateSignUpDto signUpDto) {
+        if(corporateRepository.existsCorporateByRegistrationNumber(signUpDto.getRegistrationNumber()))
+            throw new MemberDuplicateException();
+
+        return new Corporate(signUpDto.getName(), signUpDto.getBirth(), passwordEncoder.encode(signUpDto.getPassword()),
+                signUpDto.getEmail(), signUpDto.getRegistrationNumber());
+    }
+}

--- a/precending/src/main/java/umc/precending/service/redis/RedisService.java
+++ b/precending/src/main/java/umc/precending/service/redis/RedisService.java
@@ -1,0 +1,33 @@
+package umc.precending.service.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import umc.precending.exception.token.TokenNotCorrectException;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, String> template;
+
+    public void saveValue(String key, String value) {
+        ValueOperations<String, String> operations = template.opsForValue();
+        operations.set(key, value);
+    }
+
+    public String getValue(String key) {
+        ValueOperations<String, String> operations = template.opsForValue();
+        return operations.get(key);
+    }
+
+    public boolean checkValidation(String key, String tokenValue) {
+        ValueOperations<String, String> operations = template.opsForValue();
+        String storedValue = operations.get(key);
+
+        if(!storedValue.equals(tokenValue)) throw new TokenNotCorrectException();
+
+        return true;
+    }
+}


### PR DESCRIPTION
Spring Security와 JWT를 활용한 회원가입, 로그인 기능을 추가하였습니다.

- 회원가입
    - 회원별로 회원가입에 필요한 정보가 다르기에, 회원별로 별도의 API를 통하여 회원가입할 수 있도록 로직을 작성하였습니다.

- 로그인
    - 로그인의 경우, 이메일과 비밀번호를 통하여 수행할 수 있기 때문에 로그인의 경우에는 동일한 API를 통해 로직을 수행할 수 있도록 하였습니다.

현재 프론트 팀원분들과의 협업을 위하여 Swagger, Cors 설정까지 해놓은 상황입니다.

문제가 있을 경우 지적해주신다면 감사하겠습니다.