### PR TITLE
S3를 통한 이미지 저장 기능 추가

### DIFF
--- a/precending/build.gradle
+++ b/precending/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.445'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/precending/src/main/java/umc/precending/advice/ExceptionAdvice.java
+++ b/precending/src/main/java/umc/precending/advice/ExceptionAdvice.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import umc.precending.exception.email.AuthNumNotCorrectException;
+import umc.precending.exception.image.ImageNotSupportedException;
 import umc.precending.exception.member.MemberDuplicateException;
 import umc.precending.exception.member.MemberLoginFailureException;
 import umc.precending.exception.member.MemberNotFoundException;
@@ -43,6 +44,12 @@ public class ExceptionAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Response tokenNotCorrectException() {
         return Response.failure(400, "저장된 토큰의 정보와 일치하지 않습니다.");
+    }
+
+    @ExceptionHandler(ImageNotSupportedException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response imageNotSupportedException(ImageNotSupportedException e) {
+        return Response.failure(400, e.getMessage());
     }
 
     @ExceptionHandler(AuthNumNotCorrectException.class)

--- a/precending/src/main/java/umc/precending/config/S3Config.java
+++ b/precending/src/main/java/umc/precending/config/S3Config.java
@@ -1,0 +1,31 @@
+package umc.precending.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+    }
+}

--- a/precending/src/main/java/umc/precending/controller/member/MemberController.java
+++ b/precending/src/main/java/umc/precending/controller/member/MemberController.java
@@ -1,0 +1,40 @@
+package umc.precending.controller.member;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import umc.precending.domain.member.Member;
+import umc.precending.exception.member.MemberNotFoundException;
+import umc.precending.repository.member.MemberRepository;
+import umc.precending.service.member.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MemberController {
+
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
+
+    @PostMapping("/member/image")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "이미지 저장", notes = "회원의 프로필 이미지를 저장하는 로직")
+    @ApiImplicitParam(name = "file", value = "회원의 프로필 이미지 설정을 위한 이미지 파일")
+    public void saveImage(@ModelAttribute MultipartFile file) {
+        Member member = getMember();
+        memberService.saveImage(file, member);
+    }
+
+    // 현재 로그인하고 있는 사용자의 정보를 통해 정보 반환
+    public Member getMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        return memberRepository.findMemberByUsername(authentication.getName())
+                .orElseThrow(MemberNotFoundException::new);
+    }
+}

--- a/precending/src/main/java/umc/precending/domain/image/Image.java
+++ b/precending/src/main/java/umc/precending/domain/image/Image.java
@@ -1,0 +1,63 @@
+package umc.precending.domain.image;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.precending.exception.image.ImageNotSupportedException;
+
+import javax.persistence.*;
+import java.util.Arrays;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "image")
+@DiscriminatorColumn
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
+public abstract class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    protected Long id;
+
+    @Column(name = "originalName", nullable = false)
+    protected String originalName; // 이미지 파일 본래의 이름
+
+    @Column(name = "storedName", nullable = false)
+    protected String storedName; // 저장소에 저장될 경우 사용하게 될 이미지 파일의 이름
+
+    @Column(name = "accessUrl", nullable = false)
+    protected String accessUrl; // 이미지 파일에 접근하기 위한 URL
+
+    private final static String[] extensionArr = {"jpg", "jpeg", "bmp", "gif", "png"};
+
+    // accessUrl을 설정하는 메서드
+    public void setAccessUrl(String accessUrl) {
+        this.accessUrl = accessUrl;
+    }
+
+    // 이미지 파일의 확장자를 추출하는 메서드
+    public String extractExtension(String originalName) {
+        int index = originalName.lastIndexOf('.');
+
+        return originalName.substring(index + 1);
+    }
+
+    // 저장시에 활용할 새로운 이름을 생성하는 메서드
+    public String generateStoreName(String originalName) {
+        String extension = extractExtension(originalName);
+
+        if(!checkValidation(extension)) throw new ImageNotSupportedException(extension + "은 지원하지 않는 확장자입니다.");
+
+        return UUID.randomUUID() + "." + extension;
+    }
+
+    // 이미지 파일의 확장자를 통하여 유효한 이미지 파일인지 확인하는 메서드
+    public boolean checkValidation(String extension) {
+        return Arrays.stream(extensionArr)
+                .anyMatch(value -> value.equals(extension));
+    }
+}

--- a/precending/src/main/java/umc/precending/domain/image/MemberImage.java
+++ b/precending/src/main/java/umc/precending/domain/image/MemberImage.java
@@ -1,0 +1,35 @@
+package umc.precending.domain.image;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.springframework.web.multipart.MultipartFile;
+import umc.precending.domain.member.Member;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Table(name = "memberImage")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberImage extends Image {
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member member;
+
+    public MemberImage(MultipartFile file) {
+        this.originalName = file.getOriginalFilename();
+        this.storedName = generateStoreName(originalName);
+        this.accessUrl = "";
+    }
+
+    // Member에 대한 참조를 설정하는 메서드
+    public void initMember(Member member) {
+        if(this.member == null) this.member = member;
+    }
+}

--- a/precending/src/main/java/umc/precending/domain/member/Member.java
+++ b/precending/src/main/java/umc/precending/domain/member/Member.java
@@ -2,8 +2,12 @@ package umc.precending.domain.member;
 
 import lombok.*;
 import umc.precending.domain.base.BaseEntity;
+import umc.precending.domain.image.Image;
+import umc.precending.domain.image.MemberImage;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -42,4 +46,14 @@ public abstract class Member extends BaseEntity {
 
     @Enumerated(value = EnumType.STRING)
     protected Authority authority; // 사용자가 어떠한 회원인지를 명시(ex) 개인 회원, 동아리 회원, 기업 회원 등)
+
+    @OneToMany(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY, mappedBy = "member", orphanRemoval = true)
+    protected List<MemberImage> images = new ArrayList<>();
+
+    public  void saveImage(List<MemberImage> images) {
+        for(MemberImage image : images) {
+            image.initMember(this);
+            this.images.add(image);
+        }
+    }
 }

--- a/precending/src/main/java/umc/precending/exception/image/ImageNotSupportedException.java
+++ b/precending/src/main/java/umc/precending/exception/image/ImageNotSupportedException.java
@@ -1,0 +1,8 @@
+package umc.precending.exception.image;
+
+public class ImageNotSupportedException extends RuntimeException {
+
+    public ImageNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/precending/src/main/java/umc/precending/service/email/MailService.java
+++ b/precending/src/main/java/umc/precending/service/email/MailService.java
@@ -13,7 +13,6 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import java.security.SecureRandom;
 import java.util.Optional;
-import java.util.Random;
 
 @Service
 public class MailService {
@@ -25,16 +24,11 @@ public class MailService {
     @Autowired
     private MemberRepository memberRepository;
 
-
     private int authNumber;
-
-
-
 
     public void CheckAuthNum(String email,String authNum){
         redisUtil.checkEmailNumValidation(email,authNum);
     }
-
 
     //임의의 6자리 양수를 반환합니다.
     public void makeRandomNumber() {
@@ -47,12 +41,11 @@ public class MailService {
         authNumber = Integer.parseInt(randomNumber);
     }
 
-
     //mail을 어디서 보내는지, 어디로 보내는지 , 인증 번호를 html 형식으로 어떻게 보내는지 작성합니다.
     public void joinEmail(String email) {
         ExistEmail(email);
         makeRandomNumber();
-        String setFrom = "dionisos198@naver.com"; // email-config에 설정한 자신의 이메일 주소를 입력
+        String setFrom = "chrkb1569@naver.com"; // email-config에 설정한 자신의 이메일 주소를 입력
         String toMail = email;
         String title = "회원 가입 인증 이메일 입니다."; // 이메일 제목
         String content =

--- a/precending/src/main/java/umc/precending/service/image/ImageService.java
+++ b/precending/src/main/java/umc/precending/service/image/ImageService.java
@@ -1,0 +1,7 @@
+package umc.precending.service.image;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageService {
+    String saveImage(MultipartFile file, String storedName); // 이미지 파일을 새롭게 저장하는 로직, 저장시 접근 URL 반환
+}

--- a/precending/src/main/java/umc/precending/service/image/ImageServiceImpl.java
+++ b/precending/src/main/java/umc/precending/service/image/ImageServiceImpl.java
@@ -1,0 +1,34 @@
+package umc.precending.service.image;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.bucketName}")
+    private String bucketName;
+
+    @Override
+    public String saveImage(MultipartFile file, String storedName) {
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(file.getContentType());
+            metadata.setContentLength(file.getInputStream().available());
+
+            amazonS3Client.putObject(bucketName, storedName, file.getInputStream(), metadata);
+            return amazonS3Client.getUrl(bucketName, storedName).toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/precending/src/main/java/umc/precending/service/member/MemberService.java
+++ b/precending/src/main/java/umc/precending/service/member/MemberService.java
@@ -1,0 +1,38 @@
+package umc.precending.service.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import umc.precending.domain.image.Image;
+import umc.precending.domain.image.MemberImage;
+import umc.precending.domain.member.Member;
+import umc.precending.service.image.ImageService;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final ImageService imageService;
+
+    // 회원의 프로필을 설정하는 로직
+    @Transactional
+    public void saveImage(MultipartFile file, Member member) {
+        Image image = getMemberImage(file);
+        saveMemberImage(file, image);
+
+        member.saveImage(List.of((MemberImage)image));
+    }
+
+    public Image getMemberImage(MultipartFile file) {
+        return new MemberImage(file);
+    }
+
+    public void saveMemberImage(MultipartFile file, Image image) {
+        String storedName = image.getStoredName();
+
+        String accessUrl = imageService.saveImage(file, storedName);
+        image.setAccessUrl(accessUrl);
+    }
+}

--- a/precending/src/test/java/umc/precending/domain/ImageTest.java
+++ b/precending/src/test/java/umc/precending/domain/ImageTest.java
@@ -1,0 +1,64 @@
+package umc.precending.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.multipart.MultipartFile;
+import umc.precending.domain.image.Image;
+import umc.precending.domain.image.MemberImage;
+
+@ExtendWith(SpringExtension.class)
+public class ImageTest {
+
+    private Image image;
+
+    @BeforeEach
+    public void initImage() {
+        MultipartFile file = new MockMultipartFile("test.jpeg", "test.jpeg",
+                MediaType.IMAGE_JPEG.toString(), "test".getBytes());
+        image = new MemberImage(file);
+    }
+
+    @Test
+    @DisplayName(value = "확장자 추출 메서드 테스트")
+    public void extractExtensionTest() {
+        //given
+
+        //when
+        String extension = image.extractExtension("test.jpeg");
+
+        //then
+        Assertions.assertThat(extension).isEqualTo("jpeg");
+    }
+
+    @Test
+    @DisplayName(value = "저장 이름 생성 메서드 테스트")
+    public void generateStoreNameTest() {
+        //given
+
+        //when
+        String originalName = "test.jpeg";
+        String storedName = image.generateStoreName(originalName);
+
+        //then
+        Assertions.assertThat(originalName).isNotEqualTo(storedName);
+    }
+
+    @Test
+    @DisplayName(value = "확장자 유효성 확인 테스트")
+    public void checkValidationTest() {
+        //given
+
+        //when
+        String notValid = "test.txt";
+        boolean result = image.checkValidation(notValid);
+
+        //then
+        Assertions.assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
- S3 의존성 추가
    - AWS S3를 통하여 이미지를 관리하도록 설정하였습니다.

- Image, MemberImage 도메인 추가
    - 회원의 프로필 이미지를 관리하기 위한 MemberImage를 추가하였습니다.
    - 추후에 가게나 선행 게시글에도 이미지를 활용할 것 같아 Image 도메인을 추상 클래스로 설계하고 이를 상속받도록 설정하였습니다.