### PR TITLE
[Refactor] Post 도메인 관련 리팩터링

### DIFF
--- a/precending/src/main/java/umc/precending/controller/post/PostController.java
+++ b/precending/src/main/java/umc/precending/controller/post/PostController.java
@@ -1,33 +1,31 @@
 package umc.precending.controller.post;
 
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import umc.precending.domain.member.Member;
 import umc.precending.dto.post.PostEditDto;
 import umc.precending.dto.post.PostNewsCreateDto;
+import umc.precending.dto.post.PostNewsEditDto;
 import umc.precending.dto.post.PostNormalCreateDto;
-import umc.precending.exception.member.MemberNotFoundException;
-import umc.precending.repository.member.MemberRepository;
 import umc.precending.response.Response;
+import umc.precending.service.member.MemberFindService;
 import umc.precending.service.post.PostService;
-
-import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "게시글 관련 API", description = "게시글 작성, 조회, 수정, 삭제와 관련된 로직을 수행하기 위한 Controller입니다.")
 public class PostController {
-
+    private final MemberFindService memberFindService;
     private final PostService postService;
-    private final MemberRepository memberRepository;
 
     @GetMapping("/posts/{year}/{month}")
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "게시글 전체 조회", notes = "사용자가 작성한 모든 게시글들을 조회하는 로직")
+    @Operation(method = "GET", summary = "사용자 전체 게시글 조회 - 선행 일자 기준", description = "사용자의 선행 일자를 기준으로 게시글을 조회하는 API")
     public Response findAll(@PathVariable int year, @PathVariable int month) {
         Member findMember = getMember();
         return Response.success(postService.findAll(year, month, findMember));
@@ -35,76 +33,88 @@ public class PostController {
 
     @GetMapping("/posts/{id}")
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "게시글 단일 조회", notes = "게시글의 id를 통하여 특정 게시글을 조회하는 로직")
+    @Operation(method = "GET", summary = "단일 게시글 조회", description = "PK값을 통하여 특정 게시글을 조회하는 API")
     public Response findOne(@PathVariable Long id) {
         return Response.success(postService.findOne(id));
     }
 
     @GetMapping("/posts/corporate")
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "최신 기업 게시글 조회", notes = "기업이 작성한 최신 뉴스들을 조회하는 로직")
+    @Operation(method = "GET", summary = "기업 작성 게시글 조회", description = "기업 회원이 작성한 게시글들을 조회하는 API")
     public Response findCorporatePost() {
         return Response.success(postService.getCorporatePost());
     }
 
-    @PostMapping("/posts/valid/news")
-    @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "인증 가능 게시글 생성 - 기사", notes = "인증 가능한 기사 게시글을 생성하는 로직")
-    public void makeValidateNews(@ModelAttribute @Valid PostNewsCreateDto createDto) {
-        Member findMember = getMember();
-        postService.makeValidateNews(createDto, findMember);
+    @GetMapping("/posts/club")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "GET", summary = "동아리 작성 게시글 조회", description = "동아리 회원이 작성한 게시글들을 조회하는 API")
+    public Response findClubPost() {
+        return Response.success(postService.getClubPost());
     }
 
-    @PostMapping("/posts/valid/post")
+    @GetMapping("/admin/posts")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "GET", summary = "인증 가능한 게시글 조회 - 관리자용", description = "관리자가 인증 가능한 게시글들을 조회하는 API")
+    public Response findValidPosts() {
+        return Response.success(postService.findVerifiablePost());
+    }
+
+    @PostMapping("/posts/valid/normal")
     @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "인증 가능 게시글 생성 - 일반 게시글", notes = "인증 기능한 일반 게시글을 생성하는 로직")
+    @Operation(method = "POST", summary = "인증 가능한 게시글 생성 - 일반", description = "사진을 첨부하여 인증 가능한 게시글을 작성하는 API")
     public void makeValidatePost(@ModelAttribute @Valid PostNormalCreateDto createDto) {
         Member findMember = getMember();
         postService.makeValidateNormalPost(createDto, findMember);
     }
 
-    @GetMapping("/posts/valid")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "인증 가능한 게시글 조회", notes = "인증이 가능한 게시글만을 조회하는 로직")
-    public Response findValidPosts() {
-        return Response.success(postService.findVerifiablePost());
-    }
-
-    @PutMapping("/posts/valid/{id}")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "인증 여부 확인", notes = "인증 가능한 게시글의 유효성을 판단하는 로직")
-    public void checkPostValidation(@PathVariable Long id) {
-        postService.checkPostValidation(id);
-    }
-
-    @PostMapping("/posts/normal/post")
+    @PostMapping("/posts/valid/news")
     @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "인증 불가능한 게시글 생성 - 일반 게시글", notes = "인증할 수 없는 일반 게시글을 생성하는 로직")
+    @Operation(method = "POST", summary = "인증 가능한 게시글 생성 - 뉴스", description = "뉴스 링크를 첨부하여 인증 가능한 게시글을 작성하는 API")
+    public void makeValidateNews(@ModelAttribute @Valid PostNewsCreateDto createDto) {
+        Member findMember = getMember();
+        postService.makeValidateNews(createDto, findMember);
+    }
+
+    @PostMapping("/posts/invalid/normal")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(method = "POST", summary = "인증 불가능한 게시글 생성", description = "인증이 불가능한 게시글을 작성하는 API")
     public void makeNormalPost(@ModelAttribute @Valid PostNormalCreateDto createDto) {
         Member findMember = getMember();
         postService.makeNormalPost(createDto, findMember);
     }
 
-    @PutMapping("/posts/{id}")
+    @PutMapping("/admin/posts/valid/{id}")
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "게시글 수정", notes = "게시글을 수정하는 로직")
-    public void editNewsPost(@ModelAttribute @Valid PostEditDto editDto, @PathVariable Long id) {
+    @Operation(method = "PUT", summary = "게시글 인증 - 관리자용", description = "인증 가능한 게시글을 관리자가 판단하기 위한 API")
+    public void checkPostValidation(@PathVariable Long id) {
+        postService.checkPostValidation(id);
+    }
+
+    @PutMapping("/posts/normal/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "PUT", summary = "일반 게시글 수정", description = "일반 게시글을 수정하기 위한 API")
+    public void editNormalPost(@ModelAttribute @Valid PostEditDto editDto, @PathVariable Long id) {
         Member findMember = getMember();
-        postService.editPost(editDto, findMember, id);
+        postService.editNormalPost(editDto, findMember, id);
+    }
+
+    @PutMapping("/posts/news/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "PUT", summary = "뉴스 게시글 수정", description = "뉴스 게시글을 수정하기 위한 API")
+    public void editNewsPost(@ModelAttribute @Valid PostNewsEditDto editDto, @PathVariable Long id) {
+        Member findMember = getMember();
+        postService.editNewsPost(editDto, findMember, id);
     }
 
     @DeleteMapping("/posts/{id}")
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "게시글 삭제", notes = "게시글을 삭제하는 로직")
+    @Operation(method = "DELETE", summary = "게시글 삭제", description = "게시글을 삭제하기 위한 API")
     public void deletePost(@PathVariable Long id) {
         Member findMember = getMember();
         postService.deletePost(findMember, id);
     }
 
     private Member getMember() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String username = authentication.getName();
-
-        return memberRepository.findMemberByUsername(username).orElseThrow(MemberNotFoundException::new);
+        return memberFindService.findCurrentMember();
     }
 }

--- a/precending/src/main/java/umc/precending/domain/category/Category.java
+++ b/precending/src/main/java/umc/precending/domain/category/Category.java
@@ -1,0 +1,35 @@
+package umc.precending.domain.category;
+
+import lombok.Getter;
+import umc.precending.exception.category.CategoryNotFoundException;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Getter
+public enum Category {
+    CATEGORY_1("기부"),
+    CATEGORY_2("돕기"),
+    CATEGORY_3("배려"),
+    CATEGORY_4("용기"),
+    CATEGORY_5("양보")
+    ;
+
+    public final static int MIN_RANGE = 1;
+    public final static int MAX_RANGE = 2;
+    private final String categoryName;
+
+    Category(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public static Category getCategoryByName(String categoryName) {
+        Optional<Category> category = Arrays.stream(values())
+                .filter(value -> value.getCategoryName().equals(categoryName))
+                .findFirst();
+
+        if(category.isEmpty()) throw new CategoryNotFoundException();
+
+        return category.get();
+    }
+}

--- a/precending/src/main/java/umc/precending/domain/category/PostCategory.java
+++ b/precending/src/main/java/umc/precending/domain/category/PostCategory.java
@@ -1,0 +1,42 @@
+package umc.precending.domain.category;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+public class PostCategory {
+    private final String BASIC_CATEGORY = "EMPTY";
+    private final static int CATEGORY_MAX_SIZE = 2;
+
+    @Column(name = "first_category", nullable = false)
+    private String firstCategory;
+    @Column(name = "second_category", nullable = false)
+    private String secondCategory;
+
+    public PostCategory(List<Category> categoryList) {
+        if(categoryList.size() < CATEGORY_MAX_SIZE) {
+            this.firstCategory = categoryList.get(0).getCategoryName();
+            this.secondCategory = BASIC_CATEGORY;
+            return;
+        }
+
+        this.firstCategory = categoryList.get(0).getCategoryName();
+        this.secondCategory = categoryList.get(1).getCategoryName();
+    }
+
+    public List<String> getCategoryList() {
+        List<String> categoryList = new ArrayList<>();
+
+        categoryList.add(firstCategory);
+        if(!secondCategory.equals(BASIC_CATEGORY)) categoryList.add(secondCategory);
+
+        return categoryList;
+    }
+}

--- a/precending/src/main/java/umc/precending/domain/post/NewsPost.java
+++ b/precending/src/main/java/umc/precending/domain/post/NewsPost.java
@@ -1,59 +1,47 @@
 package umc.precending.domain.post;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.precending.domain.category.Category;
 import umc.precending.domain.category.PostCategory;
 import umc.precending.domain.image.PostImage;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Lob;
 import java.util.List;
 
 @Entity
 @Getter
 @AllArgsConstructor
+@Table(name = "NEWS_POST")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NewsPost extends Post {
     @Column(name = "newsUrl", nullable = false)
     private String newsUrl; // 뉴스에 접근하기 위한 뉴스 링크
 
-    @Column(name = "content", nullable = false)
-    @Lob
-    private String content; // 뉴스 본문
-
     public NewsPost(String writer, String newsUrl, String content,
-                    int year, int month, int day,
-                    List<PostCategory> categories, List<PostImage> images) {
-        this.writer = writer;
-        this.verifiable = true;
-        this.isVerified = false;
+                    int year, int month, int date,
+                    List<Category> categoryList, List<PostImage> imageList) {
+        super(year, month, date, content, writer, true, categoryList, imageList);
         this.newsUrl = newsUrl;
-        this.content = content;
-        this.year = year;
-        this.month = month;
-        this.day = day;
-        addCategories(categories);
-        addImages(images);
+    }
+
+    public void editPost(int year, int month, int date, String newsUrl, String content, List<Category> categories) {
+        editPrecedingDate(year, month, date);
+        updateNews(newsUrl, content);
+        this.postCategory = new PostCategory(categories);
+    }
+
+    public void editPost(int year, int month, int date, List<Category> categories) {
+        editPrecedingDate(year, month, date);
+        this.postCategory = new PostCategory(categories);
     }
 
     private void updateNews(String newsUrl, String content) {
         this.newsUrl = newsUrl;
         this.content = content;
-    }
-
-    public void editPost(int year, int month, int day, String newsUrl, String content) {
-        this.year = year;
-        this.month = month;
-        this.day = day;
-        updateNews(newsUrl, content);
-    }
-
-    public void editPost(int year, int month, int day) {
-        this.year = year;
-        this.month = month;
-        this.day = day;
     }
 }

--- a/precending/src/main/java/umc/precending/domain/post/PrecedingDate.java
+++ b/precending/src/main/java/umc/precending/domain/post/PrecedingDate.java
@@ -1,0 +1,22 @@
+package umc.precending.domain.post;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class PrecedingDate {
+    @Column(name = "preceding_year", nullable = false)
+    private int year;
+
+    @Column(name = "preceding_month", nullable = false)
+    private int month;
+
+    @Column(name = "preceding_date", nullable = false)
+    private int date;
+}

--- a/precending/src/main/java/umc/precending/dto/post/PostNewsCreateDto.java
+++ b/precending/src/main/java/umc/precending/dto/post/PostNewsCreateDto.java
@@ -1,36 +1,38 @@
 package umc.precending.dto.post;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PostNewsCreateDto {
     @NotBlank(message = "선행을 기록하기 위한 기사 링크를 입력해주세요.")
+    @Schema(description = "선행과 관련된 기사의 링크(다음, 네이버 기사만 지원합니다.)", example = "https://www.test.com")
     private String newsUrl;
 
     @NotNull(message = "선행을 수행한 연도를 입력해주세요")
+    @Schema(description = "선행을 수행한 일자 - 연도", example = "9999")
     private Integer year;
 
     @NotNull(message = "선행을 수행한 월을 입력해주세요")
+    @Schema(description = "선행을 수행한 일자 - 월", example = "12")
     private Integer month;
 
     @NotNull(message = "선행을 수행한 일자를 입력해주세요")
+    @Schema(description = "선행을 수행한 일자 - 일", example = "31")
     private Integer day;
 
     @NotNull(message = "선행을 기록하기 위한 카테고리를 입력해주세요.")
-    List<Long> categories = new ArrayList<>();
-
-    private boolean type; // 기부 형태, true일 경우 일시적 기부, false일 경우에는 정기 기부
-
-    private Double donation; // 기부 금액
+    @Schema(description = "선행과 관련된 카테고리", example = "배려, 양보")
+    List<String> categories = new ArrayList<>();
 }

--- a/precending/src/main/java/umc/precending/dto/post/PostNewsEditDto.java
+++ b/precending/src/main/java/umc/precending/dto/post/PostNewsEditDto.java
@@ -6,19 +6,18 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
-@AllArgsConstructor
 @NoArgsConstructor
-public class PostEditDto {
-    @NotNull(message = "수정할 선행 내용을 입력해주세요.")
-    @Schema(description = "게시글에 기입하기 위한 선행 내용", example = "test")
-    private String content;
+@AllArgsConstructor
+public class PostNewsEditDto {
+    @NotNull(message = "수정할 기사 링크를 입력해주세요.")
+    @Schema(description = "게시글에 기입하기 위한 기사 링크(다음, 네이버만 지원)", example = "https://www.test.com")
+    private String newsUrl;
 
     @NotNull(message = "수정할 선행 일자(연도)를 입력해주세요.")
     @Schema(description = "선행을 수행한 일자 - 연도", example = "9999")
@@ -35,7 +34,4 @@ public class PostEditDto {
     @NotNull(message = "수정할 선행 카테고리를 입력해주세요.")
     @Schema(description = "선행과 관련된 카테고리", example = "배려, 양보")
     private List<String> categories = new ArrayList<>();
-
-    @Schema(description = "선행과 관련된 이미지")
-    private List<MultipartFile> files = new ArrayList<>();
 }

--- a/precending/src/main/java/umc/precending/dto/post/PostNewsResponseDto.java
+++ b/precending/src/main/java/umc/precending/dto/post/PostNewsResponseDto.java
@@ -1,0 +1,17 @@
+package umc.precending.dto.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.precending.domain.post.NewsPost;
+import umc.precending.domain.post.Post;
+
+@Getter
+@NoArgsConstructor
+public class PostNewsResponseDto extends PostResponseDto {
+    private String newsUrl;
+
+    public PostNewsResponseDto(Post post) {
+        super(post);
+        this.newsUrl = ((NewsPost)post).getNewsUrl();
+    }
+}

--- a/precending/src/main/java/umc/precending/dto/post/PostNormalCreateDto.java
+++ b/precending/src/main/java/umc/precending/dto/post/PostNormalCreateDto.java
@@ -1,40 +1,43 @@
 package umc.precending.dto.post;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PostNormalCreateDto {
     @NotBlank(message = "선행을 기록하기 위한 내용을 입력해주세요.")
+    @Schema(description = "게시글에 기입하기 위한 선행 내용", example = "test")
     private String content; // 게시글을 생성할 때 필요한 본문 내용
 
     @NotNull(message = "선행을 수행한 연도를 입력해주세요")
-    private Integer year;
+    @Schema(description = "선행을 수행한 일자 - 연도", example = "9999")
+    private int year;
 
     @NotNull(message = "선행을 수행한 월을 입력해주세요")
-    private Integer month;
+    @Schema(description = "선행을 수행한 일자 - 월", example = "12")
+    private int month;
 
     @NotNull(message = "선행을 수행한 일자를 입력해주세요")
-    private Integer day;
+    @Schema(description = "선행을 수행한 일자 - 일", example = "31")
+    private int day;
 
     @NotNull(message = "선행을 기록하기 위한 이미지를 입력해주세요.")
+    @Schema(description = "선행과 관련된 이미지")
     private List<MultipartFile> files = new ArrayList<>(); // 게시글에 첨부할 이미지
 
     @NotNull(message = "선행을 기록하기 위한 카테고리를 입력해주세요.")
-    private List<Long> categories = new ArrayList<>(); // 게시글에 추가할 카테고리 정보
-
-    private boolean type; // 기부 형태, true일 경우 일시적 기부, false일 경우에는 정기 기부
-
-    private Double donation; // 기부 금액
+    @Schema(description = "선행과 관련된 카테고리", example = "배려, 양보")
+    private List<String> categories = new ArrayList<>(); // 게시글에 추가할 카테고리 정보
 }

--- a/precending/src/main/java/umc/precending/dto/post/PostResponseDto.java
+++ b/precending/src/main/java/umc/precending/dto/post/PostResponseDto.java
@@ -1,20 +1,55 @@
 package umc.precending.dto.post;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import umc.precending.domain.post.NewsPost;
-import umc.precending.domain.post.NormalPost;
+import umc.precending.domain.category.PostCategory;
+import umc.precending.domain.image.PostImage;
 import umc.precending.domain.post.Post;
+import umc.precending.dto.image.ImageDto;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
-public class PostResponseDto<T> {
-    private T responseData;
+public class PostResponseDto {
+    private Long id;
+    private String content;
+    private LocalDateTime firstCreatedDate;
+    private LocalDateTime lastModifiedDate;
+    private boolean verifiable;
+    private boolean isVerified;
+    private List<ImageDto> images = new ArrayList<>();
+    private List<String> categories = new ArrayList<>();
 
-    public PostResponseDto toDto(Post post) {
-        if(post instanceof NormalPost) return new PostResponseDto(new PostNormalResponseDto((NormalPost) post));
-        return new PostResponseDto(new PostNewsResponseDto((NewsPost)post));
+    public PostResponseDto(Post post) {
+        this.id = post.getId();
+        this.content = post.getContent();
+        this.firstCreatedDate = post.getFirstCreatedDate();
+        this.lastModifiedDate = post.getLastModifiedDate();
+        this.verifiable = post.isVerifiable();
+        this.isVerified = post.isVerified();
+        this.images = post.getImageList().stream()
+                .map(ImageDto::toDto).collect(Collectors.toList());
+        this.categories = List.copyOf(post.getPostCategory().getCategoryList());
+    }
+
+    @QueryProjection
+    public PostResponseDto(long id, String content, LocalDateTime firstCreatedDate, LocalDateTime lastModifiedDate,
+                           boolean verifiable, boolean isVerified,
+                           List<PostImage> imageList, PostCategory postCategory) {
+        this.id = id;
+        this.content = content;
+        this.firstCreatedDate = firstCreatedDate;
+        this.lastModifiedDate = lastModifiedDate;
+        this.verifiable = verifiable;
+        this.isVerified = isVerified;
+        this.images = imageList.stream().map(ImageDto::toDto).collect(Collectors.toList());
+        this.categories = List.copyOf(postCategory.getCategoryList());
     }
 }

--- a/precending/src/main/java/umc/precending/exception/category/CategoryOutOfRangeException.java
+++ b/precending/src/main/java/umc/precending/exception/category/CategoryOutOfRangeException.java
@@ -1,0 +1,4 @@
+package umc.precending.exception.category;
+
+public class CategoryOutOfRangeException extends RuntimeException {
+}

--- a/precending/src/main/java/umc/precending/repository/post/PostRepository.java
+++ b/precending/src/main/java/umc/precending/repository/post/PostRepository.java
@@ -2,10 +2,7 @@ package umc.precending.repository.post;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.precending.domain.post.Post;
+import umc.precending.repository.post.infra.PostQueryRepository;
 
-import java.util.List;
-
-public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findAllByWriterAndYearAndMonth(String writer, int year, int month);
-    List<Post> findPostsByVerifiableAndIsVerified(boolean verifiable, boolean ifVerified);
+public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepository {
 }

--- a/precending/src/main/java/umc/precending/repository/post/infra/PostQueryRepository.java
+++ b/precending/src/main/java/umc/precending/repository/post/infra/PostQueryRepository.java
@@ -1,0 +1,13 @@
+package umc.precending.repository.post.infra;
+
+import umc.precending.domain.member.Member;
+import umc.precending.dto.post.PostResponseDto;
+
+import java.util.List;
+
+public interface PostQueryRepository {
+    List<PostResponseDto> findPostsByPrecedingDate(Member member, int year, int month);
+    List<PostResponseDto> findPostsByCorporate();
+    List<PostResponseDto> findPostsByClub();
+    List<PostResponseDto> findVerifiablePosts();
+}

--- a/precending/src/main/java/umc/precending/repository/post/infra/PostQueryRepositoryImpl.java
+++ b/precending/src/main/java/umc/precending/repository/post/infra/PostQueryRepositoryImpl.java
@@ -1,0 +1,69 @@
+package umc.precending.repository.post.infra;
+
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import umc.precending.domain.member.Authority;
+import umc.precending.domain.member.Member;
+import umc.precending.dto.post.PostResponseDto;
+import umc.precending.dto.post.QPostResponseDto;
+
+import java.util.List;
+
+import static umc.precending.domain.member.QMember.*;
+import static umc.precending.domain.post.QPost.*;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostQueryRepositoryImpl implements PostQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public List<PostResponseDto> findPostsByPrecedingDate(Member member, int year, int month) {
+        return queryFactory.select(getResponseType())
+                .from(post)
+                .where(post.writer.eq(member.getUsername())
+                        .and(post.precedingDate.year.eq(year)
+                                .and(post.precedingDate.month.eq(month))))
+                .fetch();
+    }
+
+    @Override
+    public List<PostResponseDto> findPostsByCorporate() {
+        return queryFactory.select(getResponseType())
+                .from(post)
+                .where(findMemberByName(post.writer).eq(Authority.ROLE_CORPORATE))
+                .orderBy(post.firstCreatedDate.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<PostResponseDto> findPostsByClub() {
+        return queryFactory.select(getResponseType())
+                .from(post)
+                .where(findMemberByName(post.writer).eq(Authority.ROLE_CLUB))
+                .orderBy(post.firstCreatedDate.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<PostResponseDto> findVerifiablePosts() {
+        return queryFactory.select(getResponseType())
+                .from(post)
+                .where(post.verifiable.isTrue().and(post.isVerified.isFalse()))
+                .fetch();
+    }
+
+    private QPostResponseDto getResponseType() {
+        return new QPostResponseDto(post.id, post.content, post.firstCreatedDate,
+                post.lastModifiedDate, post.verifiable, post.isVerified,
+                post.imageList, post.postCategory);
+    }
+
+    private JPAQuery<Authority> findMemberByName(StringPath username) {
+        return queryFactory.select(member.authority)
+                .from(member)
+                .where(member.username.eq(username));
+    }
+}

--- a/precending/src/main/java/umc/precending/service/crawling/CrawlingService.java
+++ b/precending/src/main/java/umc/precending/service/crawling/CrawlingService.java
@@ -1,0 +1,91 @@
+package umc.precending.service.crawling;
+
+import lombok.RequiredArgsConstructor;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import umc.precending.dto.post.PostCrawlingResponseDto;
+import umc.precending.exception.post.PostNewsNotSupportedException;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CrawlingService {
+    @Value("${crawling.driver}")
+    private String driverUrl;
+
+    public PostCrawlingResponseDto crawlingData(String accessUrl) {
+        if(accessUrl.contains("naver")) return crawlingNaver(accessUrl);
+        else if(accessUrl.contains("daum")) return crawlingDaum(accessUrl);
+        throw new PostNewsNotSupportedException(accessUrl + "은 지원하지 않는 플랫폼입니다.");
+    }
+
+    private PostCrawlingResponseDto crawlingNaver(String accessUrl) {
+        WebDriver driver = getChromDriver();
+
+        try {
+            driver.get(accessUrl);
+            Thread.sleep(1000);
+
+            List<WebElement> elements = driver.findElements(By.id("dic_area"));
+            List<WebElement> images = driver.findElements(By.id("img1"));
+
+            String content = elements.get(0).getText();
+            String image = images.get(0).getAttribute("src");
+
+            driver.close();
+            driver.quit();
+
+            return new PostCrawlingResponseDto(content, image);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private PostCrawlingResponseDto crawlingDaum(String accessUrl) {
+        WebDriver driver = getChromDriver();
+
+        try {
+            driver.get(accessUrl);
+            Thread.sleep(1000);
+
+            List<WebElement> elements = driver.findElements(By.xpath("//*[@id=\"mArticle\"]/div[2]"));
+            List<WebElement> images = driver.findElements(By.xpath("//*[@id=\"mArticle\"]/div[2]/div[2]/section/figure[1]/p/img"));
+
+            String content = elements.get(0).getText();
+            String image = images.get(0).getAttribute("src");
+
+            driver.close();
+            driver.quit();
+
+            return new PostCrawlingResponseDto(content, image);
+
+        } catch(InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private WebDriver getChromDriver() {
+        System.setProperty("webdriver.chrome.driver", driverUrl);
+
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.setHeadless(true);
+        chromeOptions.addArguments("--lang=ko");
+        chromeOptions.addArguments("--no-sandbox");
+        chromeOptions.addArguments("--disable-dev-shm-usage");
+        chromeOptions.addArguments("--disable-gpu");
+        chromeOptions.addArguments("--remote-allow-origins=*");
+        chromeOptions.setCapability("ignoreProtectedModeSettings", true);
+
+        WebDriver driver = new ChromeDriver(chromeOptions);
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(30));
+
+        return driver;
+    }
+}

--- a/precending/src/main/java/umc/precending/service/post/PostService.java
+++ b/precending/src/main/java/umc/precending/service/post/PostService.java
@@ -1,92 +1,115 @@
 package umc.precending.service.post;
 
 import lombok.RequiredArgsConstructor;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import umc.precending.domain.post.NewsPost;
-import umc.precending.domain.post.NormalPost;
-import umc.precending.domain.post.Post;
-import umc.precending.domain.post.RecommendPost;
 import umc.precending.domain.category.Category;
-import umc.precending.domain.category.PostCategory;
+import umc.precending.domain.post.NewsPost;
+import umc.precending.domain.post.Post;
 import umc.precending.domain.image.PostImage;
-import umc.precending.domain.member.Corporate;
 import umc.precending.domain.member.Member;
 import umc.precending.dto.post.*;
-import umc.precending.exception.category.CategoryNotFoundException;
-import umc.precending.exception.member.MemberNotFoundException;
+import umc.precending.exception.category.CategoryOutOfRangeException;
 import umc.precending.exception.post.PostAuthException;
-import umc.precending.exception.post.PostNewsNotSupportedException;
 import umc.precending.exception.post.PostNotFoundException;
 import umc.precending.exception.post.PostVerifyException;
-import umc.precending.repository.category.CategoryRepository;
-import umc.precending.repository.member.MemberRepository;
 import umc.precending.repository.post.PostRepository;
+import umc.precending.service.crawling.CrawlingService;
 import umc.precending.service.image.ImageService;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static umc.precending.domain.category.Category.*;
+
 @Service
 @RequiredArgsConstructor
 public class PostService {
+    private final CrawlingService crawlingService;
     private final PostRepository postRepository;
-    private final MemberRepository memberRepository;
-    private final CategoryRepository categoryRepository;
     private final ImageService imageService;
 
-    @Value("${crawling.driver}")
-    private String driverUrl;
-
-    // 사용자가 작성한 전체 게시글 보기 - 월 단위
+    // 사용자가 작성한 전체 게시글 조회 - 선행 연월 기준
     @Transactional(readOnly = true)
     public List<PostResponseDto> findAll(int year, int month, Member member) {
-        List<Post> postList = postRepository.findAllByWriterAndYearAndMonth(member.getUsername(), year, month);
-        if(postList.isEmpty()) throw new PostNotFoundException();
+        List<PostResponseDto> responseData = postRepository.findPostsByPrecedingDate(member, year, month);
+        if(responseData.isEmpty()) throw new PostNotFoundException();
 
-        return postList.stream()
-                .map(post -> new PostResponseDto<>().toDto(post))
-                .collect(Collectors.toList());
+        return responseData;
     }
 
     // 단일 게시글 보기
     @Transactional(readOnly = true)
     public PostResponseDto findOne(Long id) {
-        Post findPost = postRepository.findById(id).orElseThrow(PostNotFoundException::new);
+        Post findPost = getPost(id);
 
-        return new PostResponseDto().toDto(findPost);
+        return getPostResponseData(findPost);
+    }
+
+    // 기업 회원이 작성한 게시글 조회 - 최신순
+    @Transactional(readOnly = true)
+    public List<PostResponseDto> getCorporatePost() {
+        List<PostResponseDto> corporatePosts = postRepository.findPostsByCorporate();
+        if(corporatePosts.isEmpty()) throw new PostNotFoundException();
+
+        return corporatePosts;
+    }
+
+    // 동아리 회원이 작성한 게시글 조회 - 최신순
+    @Transactional(readOnly = true)
+    public List<PostResponseDto> getClubPost() {
+        List<PostResponseDto> clubPosts = postRepository.findPostsByClub();
+        if(clubPosts.isEmpty()) throw new PostNotFoundException();
+
+        return clubPosts;
     }
 
     // 인증 가능한 게시글만을 조회하는 로직
     @Transactional
     public List<PostResponseDto> findVerifiablePost() {
-        List<Post> postList = postRepository.findPostsByVerifiableAndIsVerified(true, false);
-
+        List<PostResponseDto> postList = postRepository.findVerifiablePosts();
         if(postList.isEmpty()) throw new PostNotFoundException();
 
-        return postList.stream()
-                .map(post -> new PostResponseDto().toDto(post))
-                .collect(Collectors.toList());
+        return postList;
     }
 
-    @Transactional(readOnly = true)
-    public List<PostResponseDto> getCorporatePost() {
-        List<Post> recentPostList = getCorporatePosts();
-        if(recentPostList.isEmpty()) throw new PostNotFoundException();
+    // 인증이 가능한 선행 기록 - 텍스트 + 사진
+    @Transactional
+    public void makeValidateNormalPost(PostNormalCreateDto createDto, Member member) {
+        List<PostImage> images = createDto.getFiles().stream().map(PostImage::new).toList();
+        List<Category> categories = getCategories(createDto.getCategories());
 
-        return recentPostList.stream()
-                .map(value -> new PostResponseDto<>().toDto(value))
-                .collect(Collectors.toList());
+        Post post = getValidateNormalPost(createDto, member, categories, images);
+
+        addImages(createDto.getFiles(), images);
+
+        postRepository.save(post);
+    }
+
+    // 인증이 가능한 선행 기록 - 뉴스
+    @Transactional
+    public void makeValidateNews(PostNewsCreateDto createDto, Member member) {
+        PostCrawlingResponseDto responseDto = crawlingService.crawlingData(createDto.getNewsUrl());
+        List<Category> categories = getCategories(createDto.getCategories());
+        List<PostImage> images = getPostImages(responseDto);
+
+        Post post = getNewsPost(createDto, responseDto, member, categories, images);
+
+        postRepository.save(post);
+    }
+
+    // 인증이 불가능한 선행 기록 - 텍스트 + 사진
+    @Transactional
+    public void makeNormalPost(PostNormalCreateDto createDto, Member member) {
+        List<PostImage> images = createDto.getFiles().stream().map(PostImage::new).toList();
+        List<Category> categories = getCategories(createDto.getCategories());
+
+        Post post = getNormalPost(createDto, member, categories, images);
+        addImages(createDto.getFiles(), images);
+
+        postRepository.save(post);
     }
 
     // 인증 가능한 게시글을 관리자가 판단하여 인증여부를 결정하는 로직
@@ -97,200 +120,86 @@ public class PostService {
         findPost.verifyPost();
     }
 
-    // 인증이 가능한 선행 기록 - 뉴스
+    // 뉴스 게시글 수정
     @Transactional
-    public void makeValidateNews(PostNewsCreateDto createDto, Member member) {
-        PostCrawlingResponseDto responseDto = crawlingData(createDto.getNewsUrl());
-        List<PostCategory> categories = getCategories(createDto.getCategories());
-        List<PostImage> images = getPostImages(responseDto);
-
-        Post post = getNewsPost(createDto, responseDto, member, categories, images);
-
-        addCategories(createDto, categories);
-
-        postRepository.save(post);
-    }
-
-    // 인증이 가능한 선행 기록 - 텍스트 + 사진
-    @Transactional
-    public void makeValidateNormalPost(PostNormalCreateDto createDto, Member member) {
-        List<PostImage> images = createDto.getFiles().stream()
-                .map(PostImage::new).collect(Collectors.toList());
-        List<PostCategory> categories = getCategories(createDto.getCategories());
-
-        Post post = getValidateNormalPost(createDto, member, images, categories);
-        addImages(createDto.getFiles(), images);
-        addCategories(createDto, categories);
-
-        postRepository.save(post);
-    }
-
-    // 인증이 불가능한 선행 기록 - 텍스트 + 사진
-    @Transactional
-    public void makeNormalPost(PostNormalCreateDto createDto, Member member) {
-        List<PostImage> images = createDto.getFiles().stream()
-                .map(PostImage::new).collect(Collectors.toList());
-        List<PostCategory> categories = getCategories(createDto.getCategories());
-
-        Post post = getNormalPost(createDto, member, images, categories);
-        addImages(createDto.getFiles(), images);
-        addCategories(createDto, categories);
-
-        postRepository.save(post);
-    }
-
-    public void makeRecommendPost(RecommendPost recommendPost){
-        postRepository.save(recommendPost);
-    }
-
-    // 선행 기록 수정
-    @Transactional
-    public void editPost(PostEditDto editDto, Member member, Long id) {
+    public void editNewsPost(PostNewsEditDto editDto, Member member, Long id) {
         Post findPost = getPost(id, member);
+
+        editNewsPost((NewsPost) findPost, editDto);
+    }
+
+    // 일반 게시글 수정
+    @Transactional
+    public void editNormalPost(PostEditDto editDto, Member member, Long id) {
+        Post findPost = getPost(id, member);
+
         editPost(findPost, editDto);
     }
 
-    // 선행 기록 삭제
+    // 선행 게시글 삭제
     @Transactional
     public void deletePost(Member member, Long id) {
         Post findPost = getPost(id, member);
         postRepository.delete(findPost);
     }
 
-    private PostCrawlingResponseDto crawlingData(String accessUrl) {
-        if(accessUrl.contains("naver")) return crawlingNaver(accessUrl);
-        else if(accessUrl.contains("daum")) return crawlingDaum(accessUrl);
-        throw new PostNewsNotSupportedException(accessUrl + "은 지원하지 않는 플랫폼입니다.");
+    // 조회한 게시글 타입에 따라서 반환
+    private PostResponseDto getPostResponseData(Post post) {
+        if(post instanceof NewsPost) return new PostNewsResponseDto(post);
+        return new PostResponseDto(post);
     }
 
-    private PostCrawlingResponseDto crawlingNaver(String accessUrl) {
-        WebDriver driver = getChromDriver();
+    // 사용자로부터 입력받은 String 형식의 카테고리를 Category 객체로 변환
+    private List<Category> getCategories(List<String> categories) {
+        if(categories.size() > MAX_RANGE || categories.size() < MIN_RANGE) throw new CategoryOutOfRangeException();
 
-        try {
-            driver.get(accessUrl);
-            Thread.sleep(1000);
-
-            List<WebElement> elements = driver.findElements(By.id("dic_area"));
-            List<WebElement> images = driver.findElements(By.id("img1"));
-
-            String content = elements.get(0).getText();
-            String image = images.get(0).getAttribute("src");
-
-            driver.close();
-            driver.quit();
-
-            return new PostCrawlingResponseDto(content, image);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        return categories.stream()
+                .map(Category::getCategoryByName)
+                .collect(Collectors.toList());
     }
 
-    private PostCrawlingResponseDto crawlingDaum(String accessUrl) {
-        WebDriver driver = getChromDriver();
-
-        try {
-            driver.get(accessUrl);
-            Thread.sleep(1000);
-
-            List<WebElement> elements = driver.findElements(By.xpath("//*[@id=\"mArticle\"]/div[2]"));
-            List<WebElement> images = driver.findElements(By.xpath("//*[@id=\"mArticle\"]/div[2]/div[2]/section/figure[1]/p/img"));
-
-            String content = elements.get(0).getText();
-            String image = images.get(0).getAttribute("src");
-
-            driver.close();
-            driver.quit();
-
-            return new PostCrawlingResponseDto(content, image);
-
-        } catch(InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+    // 사용자에게 입력 받은 값을 바탕으로 인증 가능한 일반 게시글을 생성
+    private Post getValidateNormalPost(PostNormalCreateDto createDto, Member member,
+                                       List<Category> categories, List<PostImage> images) {
+        return new Post(createDto.getYear(), createDto.getMonth(), createDto.getDay(), createDto.getContent(),
+                member.getUsername(), true, categories, images);
     }
 
-    private WebDriver getChromDriver() {
-        System.setProperty("webdriver.chrome.driver", driverUrl);
-
-        ChromeOptions chromeOptions = new ChromeOptions();
-        chromeOptions.setHeadless(true);
-        chromeOptions.addArguments("--lang=ko");
-        chromeOptions.addArguments("--no-sandbox");
-        chromeOptions.addArguments("--disable-dev-shm-usage");
-        chromeOptions.addArguments("--disable-gpu");
-        chromeOptions.addArguments("--remote-allow-origins=*");
-        chromeOptions.setCapability("ignoreProtectedModeSettings", true);
-
-        WebDriver driver = new ChromeDriver(chromeOptions);
-        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(30));
-
-        return driver;
+    // 연관 관계를 맺는 메서드
+    private void addImages(List<MultipartFile> files, List<PostImage> images) {
+        IntStream.range(0, images.size()).forEach(index -> {
+            MultipartFile file = files.get(index);
+            PostImage image = images.get(index);
+            String accessUrl = imageService.saveImage(file, image.getStoredName());
+            image.setAccessUrl(accessUrl);
+        });
     }
 
-    private Post editPost(Post post, PostEditDto editDto) {
-        if(post instanceof NormalPost) return editNormalPost(post, editDto);
-        return editNewsPost(post, editDto);
+    private List<PostImage> getPostImages(PostCrawlingResponseDto responseDto) {
+        return List.of(new PostImage(responseDto.getAccessUrl() + ".jpeg", responseDto.getAccessUrl()));
     }
 
-    private Post editNormalPost(Post post, PostEditDto editDto) {
-        if(!editDto.getFiles().isEmpty()) {
-            List<PostImage> images = editDto.getFiles().stream().map(PostImage::new).collect(Collectors.toList());
-            post.editImages(images);
-            addImages(editDto.getFiles(), images);
-        }
-        if(!editDto.getCategories().isEmpty()) {
-            List<PostCategory> categories = getCategories(editDto.getCategories());
-            post.editCategories(categories);
-            addCategories(editDto, categories);
-        }
-
-        ((NormalPost)post).editPost(editDto.getYear(), editDto.getMonth(), editDto.getDay(), editDto.getContent());
-
-        return post;
+    private Post getNewsPost(PostNewsCreateDto createDto, PostCrawlingResponseDto responseDto,
+                             Member member, List<Category> categories, List<PostImage> images) {
+        return new NewsPost(member.getUsername(), createDto.getNewsUrl(), responseDto.getContent(),
+                createDto.getYear(), createDto.getMonth(), createDto.getDay(), categories, images);
     }
 
-    private Post editNewsPost(Post post, PostEditDto editDto) {
-        if(!editDto.getCategories().isEmpty()) {
-            List<PostCategory> categories = getCategories(editDto.getCategories());
-            post.editCategories(categories);
-            addCategories(editDto, categories);
-        }
-        if(!editDto.getContent().isBlank()) {
-            String newsUrl = editDto.getContent();
-            PostCrawlingResponseDto responseDto = crawlingData(newsUrl);
-            List<PostImage> images = getPostImages(responseDto);
-
-            ((NewsPost)post).editPost(editDto.getYear(), editDto.getMonth(), editDto.getDay(),
-                    responseDto.getAccessUrl(), responseDto.getContent());
-            post.editImages(images);
-
-            return post;
-        }
-
-        ((NewsPost)post).editPost(editDto.getYear(), editDto.getMonth(), editDto.getDay());
-
-        return post;
-    }
-
-    private Post getPost(Long id, Member member) {
-        Post findPost = postRepository.findById(id).orElseThrow(PostNotFoundException::new);
-
-        if(!checkValidation(member, findPost)) throw new PostAuthException();
-        return findPost;
+    private Post getNormalPost(PostNormalCreateDto createDto, Member member,
+                               List<Category> categories, List<PostImage> images) {
+        return new Post(createDto.getYear(), createDto.getMonth(), createDto.getDay(), createDto.getContent(),
+                member.getUsername(), false, categories, images);
     }
 
     private Post getPost(Long id) {
         return postRepository.findById(id).orElseThrow(PostNotFoundException::new);
     }
 
-    private List<Post> getCorporatePosts() {
-        List<Post> postList = postRepository.findAll(Sort.by(Sort.Direction.DESC, "firstCreatedDate"));
+    private Post getPost(Long id, Member member) {
+        Post findPost = postRepository.findById(id).orElseThrow(PostNotFoundException::new);
+        if(!checkValidation(member, findPost)) throw new PostAuthException();
 
-        return postList.stream()
-                .filter(post ->
-                        memberRepository
-                                .findMemberByUsername(post.getWriter())
-                                .orElseThrow(MemberNotFoundException::new) instanceof Corporate)
-                .collect(Collectors.toList());
+        return findPost;
     }
 
     private boolean checkValidation(Member member, Post post) {
@@ -301,115 +210,30 @@ public class PostService {
         if(!post.isVerifiable() || post.isVerified()) throw new PostVerifyException();
     }
 
-    private List<PostCategory> getCategories(List<Long> categories) {
-        return categories.stream()
-                .map(id -> categoryRepository.findById(id).orElseThrow(CategoryNotFoundException::new))
-                .map(PostCategory::new)
-                .collect(Collectors.toList());
-    }
+    private void editPost(Post post, PostEditDto editDto) {
+        List<MultipartFile> files = editDto.getFiles();
+        List<Category> categories = getCategories(editDto.getCategories());
 
-    private void addImages(List<MultipartFile> files, List<PostImage> images) {
-        IntStream.range(0, images.size()).forEach(index -> {
-            MultipartFile file = files.get(index);
-            PostImage image = images.get(index);
-            String accessUrl = imageService.saveImage(file, image.getStoredName());
-            image.setAccessUrl(accessUrl);
-        });
-    }
-
-    private void addCategories(PostEditDto editDto, List<PostCategory> categories) {
-        List<Long> categoryId = editDto.getCategories();
-
-        IntStream.range(0, categoryId.size()).forEach(index -> {
-            Long id = categoryId.get(index);
-            PostCategory postCategory = categories.get(index);
-            Category category = categoryRepository.findById(id).orElseThrow(CategoryNotFoundException::new);
-            setPostCategory(category, postCategory, editDto);
-
-            postCategory.initCategory(category);
-        });
-    }
-
-    private void addCategories(PostNormalCreateDto createDto, List<PostCategory> categories) {
-        List<Long> categoryId = createDto.getCategories();
-
-        IntStream.range(0, categoryId.size()).forEach(index -> {
-            Long id = categoryId.get(index);
-            PostCategory postCategory = categories.get(index);
-            Category category = categoryRepository.findById(id).orElseThrow(CategoryNotFoundException::new);
-            setPostCategory(category, postCategory, createDto);
-
-            postCategory.initCategory(category);
-        });
-    }
-
-    private void addCategories(PostNewsCreateDto createDto, List<PostCategory> categories) {
-        List<Long> categoryId = createDto.getCategories();
-
-        IntStream.range(0, categoryId.size()).forEach(index -> {
-            Long id = categoryId.get(index);
-            PostCategory postCategory = categories.get(index);
-            Category category = categoryRepository.findById(id).orElseThrow(CategoryNotFoundException::new);
-            setPostCategory(category, postCategory, createDto);
-
-            postCategory.initCategory(category);
-        });
-    }
-
-    private void setPostCategory(Category category, PostCategory postCategory, PostNormalCreateDto createDto) {
-        boolean type = createDto.isType();
-        if(!category.getCategoryName().equals("기부") || type) {
-            postCategory.updateCount(1);
+        if(files.isEmpty()) {
+            List<PostImage> images = editDto.getFiles().stream().map(PostImage::new).toList();
+            post.editInfo(editDto.getYear(), editDto.getMonth(), editDto.getDay(), editDto.getContent(), categories, images);
             return;
         }
 
-        Double donation = createDto.getDonation();
-
-        postCategory.updateCount(1 + (donation / 10000) * 0.1);
+        post.editInfo(editDto.getYear(), editDto.getMonth(), editDto.getDay(), editDto.getContent(), categories);
     }
 
-    private void setPostCategory(Category category, PostCategory postCategory, PostNewsCreateDto createDto) {
-        boolean type = createDto.isType();
-        if(!category.getCategoryName().equals("기부") || type) {
-            postCategory.updateCount(1);
+    private void editNewsPost(NewsPost post, PostNewsEditDto editDto) {
+        List<Category> categories = getCategories(editDto.getCategories());
+
+        if(editDto.getNewsUrl().equals(post.getNewsUrl())) {
+            post.editPost(editDto.getYear(), editDto.getMonth(), editDto.getDay(), categories);
             return;
         }
 
-        Double donation = createDto.getDonation();
+        PostCrawlingResponseDto responseDto = crawlingService.crawlingData(editDto.getNewsUrl());
 
-        postCategory.updateCount(1 + (donation / 10000) * 0.1);
-    }
-
-    private void setPostCategory(Category category, PostCategory postCategory, PostEditDto editDto) {
-        boolean type = editDto.isType();
-        if(!category.getCategoryName().equals("기부") || type) {
-            postCategory.updateCount(1);
-            return;
-        }
-
-        Double donation = editDto.getDonation();
-
-        postCategory.updateCount(1 + (donation / 10000) * 0.1);
-    }
-
-    private Post getValidateNormalPost(PostNormalCreateDto createDto, Member member,
-                                       List<PostImage> images, List<PostCategory> categories) {
-        return new NormalPost(member.getUsername(), createDto.getContent(), true,
-                createDto.getYear(), createDto.getMonth(), createDto.getDay(), categories, images);
-    }
-
-    private Post getNormalPost(PostNormalCreateDto createDto, Member member,
-                                       List<PostImage> images, List<PostCategory> categories) {
-        return new NormalPost(member.getUsername(), createDto.getContent(), false,
-                createDto.getYear(), createDto.getMonth(), createDto.getDay(), categories, images);
-    }
-
-    private Post getNewsPost(PostNewsCreateDto createDto, PostCrawlingResponseDto responseDto, Member member, List<PostCategory> categories, List<PostImage> images) {
-        return new NewsPost(member.getUsername(), createDto.getNewsUrl(), responseDto.getContent(),
-                createDto.getYear(), createDto.getMonth(), createDto.getDay(), categories, images);
-    }
-
-    private List<PostImage> getPostImages(PostCrawlingResponseDto responseDto) {
-        return List.of(new PostImage(responseDto.getAccessUrl() + ".jpeg", responseDto.getAccessUrl()));
+        post.editPost(editDto.getYear(), editDto.getMonth(), editDto.getDay(),
+                responseDto.getAccessUrl(), responseDto.getContent(), categories);
     }
 }

--- a/precending/src/test/java/umc/precending/controller/PostControllerTest.java
+++ b/precending/src/test/java/umc/precending/controller/PostControllerTest.java
@@ -1,0 +1,432 @@
+package umc.precending.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
+import umc.precending.controller.post.PostController;
+import umc.precending.domain.member.Member;
+import umc.precending.dto.post.*;
+import umc.precending.factory.PostFactory;
+import umc.precending.service.member.MemberFindService;
+import umc.precending.service.post.PostService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static umc.precending.factory.CategoryFactory.*;
+import static umc.precending.factory.MemberFactory.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Post [Controller Layer] -> PostController 테스트")
+public class PostControllerTest {
+    @Mock
+    private MemberFindService memberFindService;
+
+    @Mock
+    private PostService postService;
+
+    @InjectMocks
+    private PostController postController;
+
+    private MockMvc mockMvc;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void initTest() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(postController)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("전체 게시글 조회 API [GET /api/posts/{year}/{month}]")
+    class findAllTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static String BASE_URL = "/api/posts/{year}/{month}";
+        private final static int year = 12;
+        private final static int month = 31;
+
+        @Test
+        @DisplayName("전체 게시글 조회에 성공한다.")
+        public void successFindAll() throws Exception {
+            // given
+            List<PostResponseDto> responseData = new ArrayList<>();
+
+            // stub
+            given(memberFindService.findCurrentMember()).willReturn(currentMember);
+            given(postService.findAll(year, month, currentMember)).willReturn(responseData);
+
+            // when
+            mockMvc.perform(get(BASE_URL, year, month))
+                    .andExpect(status().isOk());
+
+            // then
+            verify(memberFindService).findCurrentMember();
+            verify(postService).findAll(year, month, currentMember);
+        }
+    }
+
+    @Nested
+    @DisplayName("단일 게시글 조회 API [GET /api/posts/{id}]")
+    class findOneTest {
+        private final static String BASE_URL = "/api/posts/{id}";
+        private final static long postId = 1;
+
+        @Test
+        @DisplayName("단일 게시글 조회에 성공한다.")
+        public void successFindOne() throws Exception {
+            // given
+            PostResponseDto postResponseDto = new PostResponseDto();
+
+            // stub
+            given(postService.findOne(postId)).willReturn(postResponseDto);
+
+            // when
+            mockMvc.perform(get(BASE_URL, postId))
+                    .andExpect(status().isOk());
+
+            // then
+            verify(postService).findOne(postId);
+        }
+    }
+
+    @Nested
+    @DisplayName("기업 게시글 조회 API [GET /api/posts/corporate]")
+    class findCorporatePostTest {
+        private final static String BASE_URL = "/api/posts/corporate";
+
+        @Test
+        @DisplayName("기업 게시글 조회에 성공한다.")
+        public void successFindCorporatePost() throws Exception {
+            // given
+            List<PostResponseDto> responseData = new ArrayList<>();
+
+            // stub
+            given(postService.getCorporatePost()).willReturn(responseData);
+
+            // when
+            mockMvc.perform(get(BASE_URL))
+                    .andExpect(status().isOk());
+
+            // then
+            verify(postService).getCorporatePost();
+        }
+    }
+
+    @Nested
+    @DisplayName("동아리 게시글 조회 API [GET /api/posts/club]")
+    class findClubPostTest {
+        private final static String BASE_URL = "/api/posts/club";
+
+        @Test
+        @DisplayName("동아리 게시글 조회에 성공한다.")
+        public void successFindClubPost() throws Exception {
+            // given
+            List<PostResponseDto> responseData = new ArrayList<>();
+
+            // stub
+            given(postService.getClubPost()).willReturn(responseData);
+
+            // when
+            mockMvc.perform(get(BASE_URL))
+                    .andExpect(status().isOk());
+
+            // then
+            verify(postService).getClubPost();
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 가능한 게시글 조회 API [GET /api/admin/posts]")
+    class findValidPostsTest {
+        private final static String BASE_URL = "/api/admin/posts";
+
+        @Test
+        @DisplayName("인증 가능한 게시글 조회에 성공한다.")
+        public void successFindValidPosts() throws Exception {
+            // given
+            List<PostResponseDto> responseData = new ArrayList<>();
+
+            // stub
+            given(postService.findVerifiablePost()).willReturn(responseData);
+
+            // when
+            mockMvc.perform(get(BASE_URL))
+                    .andExpect(status().isOk());
+
+            // then
+            verify(postService).findVerifiablePost();
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 가능한 일반 게시글 생성 API [POST /api/posts/valid/normal]")
+    class makeValidatePostTest {
+        private final static String BASE_URL = "/api/posts/valid/normal";
+
+        @Test
+        @DisplayName("인증 가능한 일반 게시글 생성에 성공한다.")
+        public void successMakeValidatePost() throws Exception {
+            // given
+            PostNormalCreateDto createDto = getNormalCreateDto();
+
+            // stub
+            willDoNothing().given(postService).makeValidateNormalPost(any(), any());
+
+            // when
+            mockMvc.perform(
+                    multipart(HttpMethod.POST, BASE_URL)
+                            .file("files", createDto.getFiles().get(0).getBytes())
+                            .file("files", createDto.getFiles().get(1).getBytes())
+                            .file("files", createDto.getFiles().get(2).getBytes())
+                            .param("content", createDto.getContent())
+                            .param("year", String.valueOf(createDto.getYear()))
+                            .param("month", String.valueOf(createDto.getMonth()))
+                            .param("day", String.valueOf(createDto.getDay()))
+                            .param("categories", String.valueOf(createDto.getCategories()))
+                            .accept(MediaType.MULTIPART_FORM_DATA)
+            ).andExpect(status().isCreated());
+
+            // then
+            verify(postService).makeValidateNormalPost(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 가능한 뉴스 게시글 생성 API [POST /api/posts/valid/news]")
+    class makeValidateNewsTest {
+        private final static String BASE_URL = "/api/posts/valid/news";
+
+        @Test
+        @DisplayName("인증 가능한 일반 게시글 생성에 성공한다.")
+        public void successMakeValidateNews() throws Exception {
+            // given
+            PostNewsCreateDto createDto = getNewsCreateDto();
+
+            // stub
+            willDoNothing().given(postService).makeValidateNews(any(), any());
+
+            // when
+            mockMvc.perform(
+                    multipart(HttpMethod.POST, BASE_URL)
+                            .param("newsUrl", createDto.getNewsUrl())
+                            .param("year", String.valueOf(createDto.getYear()))
+                            .param("month", String.valueOf(createDto.getMonth()))
+                            .param("day", String.valueOf(createDto.getDay()))
+                            .param("categories", String.valueOf(createDto.getCategories()))
+                            .accept(MediaType.MULTIPART_FORM_DATA)
+            ).andExpect(status().isCreated());
+
+            // then
+            verify(postService).makeValidateNews(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 불가능한 일반 게시글 생성 API [POST /api/posts/invalid/normal]")
+    class makeNormalPostTest {
+        private final static String BASE_URL = "/api/posts/invalid/normal";
+
+        @Test
+        @DisplayName("인증 가능한 일반 게시글 생성에 성공한다.")
+        public void successMakeNormalPost() throws Exception {
+            // given
+            PostNormalCreateDto createDto = getNormalCreateDto();
+
+            // stub
+            willDoNothing().given(postService).makeNormalPost(any(), any());
+
+            // when
+            mockMvc.perform(
+                    multipart(HttpMethod.POST, BASE_URL)
+                            .file("files", createDto.getFiles().get(0).getBytes())
+                            .file("files", createDto.getFiles().get(1).getBytes())
+                            .file("files", createDto.getFiles().get(2).getBytes())
+                            .param("content", createDto.getContent())
+                            .param("year", String.valueOf(createDto.getYear()))
+                            .param("month", String.valueOf(createDto.getMonth()))
+                            .param("day", String.valueOf(createDto.getDay()))
+                            .param("categories", String.valueOf(createDto.getCategories()))
+                            .accept(MediaType.MULTIPART_FORM_DATA)
+            ).andExpect(status().isCreated());
+
+            // then
+            verify(postService).makeNormalPost(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 인증 API [PUT /api/admin/posts/valid/{id}]")
+    class checkPostValidationTest {
+        private static final String BASE_URL = "/api/admin/posts/valid/{id}";
+        private static final long postId = 1;
+
+        @Test
+        @DisplayName("게시글 인증에 성공한다.")
+        public void successCheckPostValidation() throws Exception {
+            // given
+
+            // stub
+            willDoNothing().given(postService).checkPostValidation(postId);
+
+            // when
+            mockMvc.perform(put(BASE_URL, postId))
+                    .andExpect(status().isOk());
+
+            // then
+            verify(postService).checkPostValidation(postId);
+        }
+    }
+
+    @Nested
+    @DisplayName("일반 게시글 수정 API [PUT /api/posts/normal/{id}]")
+    class editNormalPostTest {
+        private final static String BASE_URL = "/api/posts/normal/{id}";
+        private final static long postId = 1;
+
+        @Test
+        @DisplayName("일반 게시글 수정에 성공한다.")
+        public void successEditNormalPost() throws Exception {
+            // given
+            PostEditDto editDto = getNormalEditDto();
+
+            // stub
+            willDoNothing().given(postService).editNormalPost(any(), any(), anyLong());
+
+            // when
+            mockMvc.perform(multipart(HttpMethod.PUT, BASE_URL, postId)
+                            .file("files", editDto.getFiles().get(0).getBytes())
+                            .file("files", editDto.getFiles().get(1).getBytes())
+                            .file("files", editDto.getFiles().get(2).getBytes())
+                            .param("content", editDto.getContent())
+                            .param("year", String.valueOf(editDto.getYear()))
+                            .param("month", String.valueOf(editDto.getMonth()))
+                            .param("day", String.valueOf(editDto.getDay()))
+                            .param("categories", String.valueOf(editDto.getCategories()))
+                    ).andExpect(status().isOk());
+
+            // then
+            verify(postService).editNormalPost(any(), any(), anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("뉴스 게시글 수정 API [PUT /api/posts/news/{id}]")
+    class editNewsPostTest {
+        private final static String BASE_URL = "/api/posts/news/{id}";
+        private final static long postId = 1;
+
+        @Test
+        @DisplayName("뉴스 게시글 수정에 성공한다.")
+        public void successEditNewsPost() throws Exception {
+            // given
+            PostNewsEditDto editDto = getNewsEditDto();
+
+            // stub
+            willDoNothing().given(postService).editNewsPost(any(), any(), anyLong());
+
+            // when
+            mockMvc.perform(multipart(HttpMethod.PUT, BASE_URL, postId)
+                            .param("newsUrl", editDto.getNewsUrl())
+                            .param("year", String.valueOf(editDto.getYear()))
+                            .param("month", String.valueOf(editDto.getMonth()))
+                            .param("day", String.valueOf(editDto.getDay()))
+                            .param("categories", String.valueOf(editDto.getCategories()))
+                    ).andExpect(status().isOk());
+
+            // then
+            verify(postService).editNewsPost(any(), any(), anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 삭제 API [DELETE /api/posts/{id}]")
+    class deletePostTest {
+        private final static String BASE_URL = "/api/posts/{id}";
+        private final static long postId = 1;
+
+        @Test
+        @DisplayName("게시글 삭제에 성공한다.")
+        public void successDeletePost() throws Exception {
+            // given
+
+            // stub
+            willDoNothing().given(postService).deletePost(any(), anyLong());
+
+            // when
+            mockMvc.perform(delete(BASE_URL, postId)).andExpect(status().isOk());
+
+            // then
+            verify(postService).deletePost(any(), anyLong());
+        }
+    }
+
+    private PostNormalCreateDto getNormalCreateDto() {
+        PostFactory postFactory = PostFactory.POST_VERIFIABLE;
+        List<MultipartFile> files = getFiles();
+        List<String> categories = getCategories();
+
+        return new PostNormalCreateDto(postFactory.getContent(), postFactory.getYear(),
+                postFactory.getMonth(), postFactory.getDate(), files, categories);
+    }
+
+    private PostNewsCreateDto getNewsCreateDto() {
+        PostFactory postFactory = PostFactory.POST_NEWS;
+        List<String> categories = getCategories();
+
+        return new PostNewsCreateDto(postFactory.getNewsUrl(), postFactory.getYear(),
+                postFactory.getMonth(), postFactory.getDate(), categories);
+    }
+
+    private PostEditDto getNormalEditDto() {
+        PostFactory postFactory = PostFactory.POST_VERIFIABLE;
+        List<MultipartFile> files = getFiles();
+        List<String> categories = getCategories();
+
+        return new PostEditDto(postFactory.getContent(), postFactory.getYear(),
+                postFactory.getMonth(), postFactory.getDate(), categories, files);
+    }
+
+    private PostNewsEditDto getNewsEditDto() {
+        PostFactory postFactory = PostFactory.POST_NEWS;
+        List<String> categories = getCategories();
+
+        return new PostNewsEditDto(postFactory.getNewsUrl(), postFactory.getYear(),
+                postFactory.getMonth(), postFactory.getDate(), categories);
+    }
+
+    private List<MultipartFile> getFiles() {
+        List<MultipartFile> files = new ArrayList<>();
+
+        files.add(new MockMultipartFile("IMAGE_1", "TEST1.jpeg", "multipart/form-data", "IMAGE_1".getBytes()));
+        files.add(new MockMultipartFile("IMAGE_2", "TEST2.jpeg", "multipart/form-data", "IMAGE_2".getBytes()));
+        files.add(new MockMultipartFile("IMAGE_3", "TEST3.jpeg", "multipart/form-data", "IMAGE_3".getBytes()));
+
+        return files;
+    }
+
+    private List<String> getCategories() {
+        List<String> categories = new ArrayList<>();
+
+        categories.add(CATEGORY_VALUE_1.getCategoryName());
+        categories.add(CATEGORY_VALUE_2.getCategoryName());
+
+        return categories;
+    }
+}

--- a/precending/src/test/java/umc/precending/domain/PostTest.java
+++ b/precending/src/test/java/umc/precending/domain/PostTest.java
@@ -1,0 +1,138 @@
+package umc.precending.domain;
+
+import org.junit.jupiter.api.*;
+import umc.precending.domain.category.Category;
+import umc.precending.domain.image.PostImage;
+import umc.precending.domain.member.Member;
+import umc.precending.domain.post.NewsPost;
+import umc.precending.domain.post.Post;
+import umc.precending.factory.CategoryFactory;
+import umc.precending.factory.ImageFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static umc.precending.factory.MemberFactory.*;
+import static umc.precending.factory.PostFactory.*;
+
+@DisplayName("Post 도메인 테스트")
+public class PostTest {
+    private Member member;
+    private Post post;
+
+    @Nested
+    @DisplayName("Post 도메인 생성 테스트")
+    class createDomainTest {
+        private final static int EMPTY_LIST_SIZE = 0;
+        @Test
+        @DisplayName("Post 도메인 생성을 테스트한다.")
+        public void createPostDomainTest() {
+            // given
+            member = MEMBER_1.getPersonalMemberInstance();
+
+            // when
+            post = POST_NOT_VERIFIABLE.getPostInstance(member);
+
+            // then
+            assertAll(
+                    () -> assertThat(post.getId()).isNull(),
+                    () -> assertThat(post.getWriter()).isEqualTo(member.getUsername()),
+                    () -> assertThat(post.getPrecedingDate().getYear()).isEqualTo(POST_NOT_VERIFIABLE.getYear()),
+                    () -> assertThat(post.getPrecedingDate().getMonth()).isEqualTo(POST_NOT_VERIFIABLE.getMonth()),
+                    () -> assertThat(post.getPrecedingDate().getDate()).isEqualTo(POST_NOT_VERIFIABLE.getDate()),
+                    () -> assertThat(post.getPostCategory().getCategoryList().size()).isNotEqualTo(EMPTY_LIST_SIZE),
+                    () -> assertThat(post.getImageList().size()).isNotEqualTo(EMPTY_LIST_SIZE),
+                    () -> assertThat(post.isVerifiable()).isEqualTo(POST_NOT_VERIFIABLE.isVerifiable())
+            );
+        }
+
+        @Test
+        @DisplayName("NewsPost 도메인 생성을 테스트한다.")
+        public void createNewsPostDomainTest() {
+            // given
+            member = MEMBER_1.getPersonalMemberInstance();
+
+            // when
+            post = POST_NOT_VERIFIABLE.getNewsPostInstance(member);
+
+            // then
+            assertAll(
+                    () -> assertThat(post.getId()).isNull(),
+                    () -> assertThat(post.getWriter()).isEqualTo(member.getUsername()),
+                    () -> assertThat(post.getPrecedingDate().getYear()).isEqualTo(POST_NOT_VERIFIABLE.getYear()),
+                    () -> assertThat(post.getPrecedingDate().getMonth()).isEqualTo(POST_NOT_VERIFIABLE.getMonth()),
+                    () -> assertThat(post.getPrecedingDate().getDate()).isEqualTo(POST_NOT_VERIFIABLE.getDate()),
+                    () -> assertThat(post.getPostCategory().getCategoryList().size()).isNotEqualTo(EMPTY_LIST_SIZE),
+                    () -> assertThat(post.getImageList().size()).isNotEqualTo(EMPTY_LIST_SIZE),
+                    () -> assertThat(post.isVerifiable()).isTrue(),
+                    () -> assertThat(((NewsPost)post).getNewsUrl()).isEqualTo(POST_NOT_VERIFIABLE.getNewsUrl())
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("editInfo() 메서드 테스트")
+    class editInfoTest {
+        private final static List<Category> otherCategories = CategoryFactory.getRandomCategoryList();
+        private final static int otherYear = 1234;
+        private final static int otherMonth = 2;
+        private final static int otherDate = 31;
+        private final static String otherContent = "Other Content";
+
+        @Test
+        @DisplayName("게시글의 정보만 수정한다.")
+        public void editInfoTestWithoutImage() {
+            // given
+            member = MEMBER_1.getPersonalMemberInstance();
+            post = POST_VERIFIABLE.getPostInstance(member);
+
+            // when
+            post.editInfo(otherYear, otherMonth, otherDate, otherContent, otherCategories);
+
+            // then
+            assertAll(
+                    () -> assertThat(post.getPrecedingDate().getYear()).isEqualTo(otherYear),
+                    () -> assertThat(post.getPrecedingDate().getMonth()).isEqualTo(otherMonth),
+                    () -> assertThat(post.getPrecedingDate().getDate()).isEqualTo(otherDate),
+                    () -> assertThat(post.getContent()).isEqualTo(otherContent),
+                    () -> assertThat(post.getPostCategory().getCategoryList())
+                            .isEqualTo(otherCategories.stream().map(Category::getCategoryName).toList())
+            );
+        }
+
+        @Test
+        @DisplayName("게시글의 이미지까지 수정한다.")
+        public void editInfoTestWithImage() {
+            // given
+            List<PostImage> images = getPostImages();
+            member = MEMBER_1.getPersonalMemberInstance();
+            post = POST_VERIFIABLE.getPostInstance(member);
+
+            // when
+            post.editInfo(otherYear, otherMonth, otherDate, otherContent, otherCategories, images);
+
+            // then
+            assertAll(
+                    () -> assertThat(post.getPrecedingDate().getYear()).isEqualTo(otherYear),
+                    () -> assertThat(post.getPrecedingDate().getMonth()).isEqualTo(otherMonth),
+                    () -> assertThat(post.getPrecedingDate().getDate()).isEqualTo(otherDate),
+                    () -> assertThat(post.getContent()).isEqualTo(otherContent),
+                    () -> assertThat(post.getPostCategory().getCategoryList())
+                            .isEqualTo(otherCategories.stream().map(Category::getCategoryName).toList()),
+                    () -> assertThat(post.getImageList().size()).isEqualTo(images.size()),
+                    () -> assertThat(post.getImageList()).isEqualTo(images)
+            );
+        }
+    }
+
+    private List<PostImage> getPostImages() {
+        List<PostImage> images = new ArrayList<>();
+
+        images.add(ImageFactory.IMAGE_1.getPostImage());
+        images.add(ImageFactory.IMAGE_2.getPostImage());
+
+        return images;
+    }
+}

--- a/precending/src/test/java/umc/precending/factory/CategoryFactory.java
+++ b/precending/src/test/java/umc/precending/factory/CategoryFactory.java
@@ -1,0 +1,62 @@
+package umc.precending.factory;
+
+import umc.precending.domain.category.Category;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static umc.precending.domain.category.Category.*;
+
+public enum CategoryFactory {
+    CATEGORY_VALUE_1(CATEGORY_1.getCategoryName()),
+    CATEGORY_VALUE_2(CATEGORY_2.getCategoryName()),
+    CATEGORY_VALUE_3(CATEGORY_3.getCategoryName()),
+    CATEGORY_VALUE_4(CATEGORY_4.getCategoryName()),
+    CATEGORY_VALUE_5(CATEGORY_5.getCategoryName())
+    ;
+    private String categoryName;
+
+    CategoryFactory(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public String getCategoryName() {
+        return this.categoryName;
+    }
+
+    public static List<Category> getRandomCategoryList() {
+        final int firstIndex = 0;
+        final int secondIndex = 1;
+
+        List<Integer> randomNumber = new ArrayList<>();
+
+        for(int number = 0; number < values().length; number++) {
+            randomNumber.add(number);
+        }
+
+        Collections.shuffle(randomNumber);
+
+        Category firstCategory = convertToCategory(randomNumber.get(firstIndex));
+        Category secondCategory = convertToCategory(randomNumber.get(secondIndex));
+
+        return List.of(firstCategory, secondCategory);
+    }
+
+    public static Category getRandomCategory() {
+        Random random = new Random();
+        int index = random.nextInt() % values().length;
+
+        return convertToCategory(index);
+    }
+
+    private static Category convertToCategory(int index) {
+        String key = getConvertKey(index);
+        return Category.getCategoryByName(key);
+    }
+
+    private static String getConvertKey(int index) {
+        return values()[index].getCategoryName();
+    }
+}

--- a/precending/src/test/java/umc/precending/factory/PostFactory.java
+++ b/precending/src/test/java/umc/precending/factory/PostFactory.java
@@ -1,0 +1,84 @@
+package umc.precending.factory;
+
+import umc.precending.domain.category.Category;
+import umc.precending.domain.image.PostImage;
+import umc.precending.domain.member.Member;
+import umc.precending.domain.post.NewsPost;
+import umc.precending.domain.post.Post;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public enum PostFactory {
+    POST_VERIFIABLE("Post Content_1", true, 9999, 12, 31, "NEWS_URL_1"),
+    POST_NOT_VERIFIABLE("Post Content_2",  false, 9999, 12, 31, "NEWS_URL_2"),
+    POST_NEWS("Post Content_3", true, 9999, 12, 31, "NEWS_URL_3")
+    ;
+    private String content;
+    private boolean verifiable;
+    private int year;
+    private int month;
+    private int date;
+
+    private String newsUrl;
+
+    PostFactory(String content, boolean verifiable, int year, int month, int date, String newsUrl) {
+        this.content = content;
+        this.verifiable = verifiable;
+        this.year = year;
+        this.month = month;
+        this.date = date;
+        this.newsUrl = newsUrl;
+    }
+
+    public Post getPostInstance(Member member) {
+        List<PostImage> images = getImageList();
+        List<Category> categories = getPostCategories();
+
+        return new Post(year, month, date, content, member.getUsername(), verifiable, categories, images);
+    }
+
+    public NewsPost getNewsPostInstance(Member member) {
+        List<PostImage> images = getImageList();
+        List<Category> categories = getPostCategories();
+
+        return new NewsPost(member.getUsername(), newsUrl, content, year, month, date, categories, images);
+    }
+
+    private List<PostImage> getImageList() {
+        List<PostImage> images = new ArrayList<>();
+
+        images.add(ImageFactory.IMAGE_1.getPostImage());
+        images.add(ImageFactory.IMAGE_2.getPostImage());
+
+        return images;
+    }
+
+    private List<Category> getPostCategories() {
+        return CategoryFactory.getRandomCategoryList();
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public boolean isVerifiable() {
+        return verifiable;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getMonth() {
+        return month;
+    }
+
+    public int getDate() {
+        return date;
+    }
+
+    public String getNewsUrl() {
+        return newsUrl;
+    }
+}

--- a/precending/src/test/java/umc/precending/service/PostServiceTest.java
+++ b/precending/src/test/java/umc/precending/service/PostServiceTest.java
@@ -1,0 +1,549 @@
+package umc.precending.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import umc.precending.domain.member.Member;
+import umc.precending.domain.post.NewsPost;
+import umc.precending.domain.post.Post;
+import umc.precending.dto.post.*;
+import umc.precending.exception.post.PostNotFoundException;
+import umc.precending.exception.post.PostVerifyException;
+import umc.precending.factory.PostFactory;
+import umc.precending.repository.post.PostRepository;
+import umc.precending.service.crawling.CrawlingService;
+import umc.precending.service.image.ImageService;
+import umc.precending.service.post.PostService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static umc.precending.factory.CategoryFactory.*;
+import static umc.precending.factory.MemberFactory.*;
+import static umc.precending.factory.PostFactory.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Post [Service Layer] -> PostService 테스트")
+public class PostServiceTest {
+    @Mock
+    private CrawlingService crawlingService;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private ImageService imageService;
+
+    @InjectMocks
+    private PostService postService;
+
+    @Nested
+    @DisplayName("사용자가 작성한 모든 게시글 조회")
+    class findAllTest {
+        private static final Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private static final int errorYear = 1234;
+        private static final int errorMonth = 13;
+
+        @Test
+        @DisplayName("조회한 결과가 존재하지 않는 경우, 오류를 반환한다.")
+        public void throwExceptionByEmptyList() {
+            // given
+            List<PostResponseDto> responseData = new ArrayList<>();
+
+            // stub
+            given(postRepository.findPostsByPrecedingDate(currentMember, errorYear, errorMonth))
+                    .willReturn(responseData);
+
+            // when - then
+            assertThatThrownBy(() -> postService.findAll(errorYear, errorMonth, currentMember))
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("사용자가 작성한 게시글 조회에 성공한다.")
+        public void successFindAll() {
+            // given
+            List<PostResponseDto> responseData = getPostResponseList();
+
+            // stub
+            given(postRepository.findPostsByPrecedingDate(any(), anyInt(), anyInt()))
+                    .willReturn(responseData);
+
+            // when
+            List<PostResponseDto> resultData = postService.findAll(anyInt(), anyInt(), any());
+
+            // then
+            assertThat(resultData).isEqualTo(responseData);
+        }
+    }
+
+    @Nested
+    @DisplayName("단일 게시글 정보 조회")
+    class findOneTest {
+        private static final long postId = 1;
+        private static final long errorId = -1;
+        
+        @Test
+        @DisplayName("유효하지 않은 PK값으로 요청하는 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidId() {
+            // given
+            // stub
+            doThrow(PostNotFoundException.class).when(postRepository).findById(errorId);
+
+            // when - then
+            assertThatThrownBy(() -> postService.findOne(errorId))
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("게시글 조회에 성공한다. - 일반 게시글")
+        public void successFindOne_Normal() {
+            // given
+            Member currentMember = MEMBER_1.getPersonalMemberInstance();
+            Post post = POST_VERIFIABLE.getPostInstance(currentMember);
+
+            // stub
+            given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+            // when
+            PostResponseDto responseData = postService.findOne(postId);
+
+            // then
+            assertAll(
+                    () -> assertThat(responseData.getContent()).isEqualTo(post.getContent()),
+                    () -> assertThat(responseData.getImages().size()).isEqualTo(post.getImageList().size()),
+                    () -> assertThat(responseData.getCategories()).isEqualTo(post.getPostCategory().getCategoryList())
+            );
+        }
+
+        @Test
+        @DisplayName("게시글 조회에 성공한다. - 뉴스 게시글")
+        public void successFindOne_News() {
+            // given
+            Member currentMember = MEMBER_1.getPersonalMemberInstance();
+            Post post = POST_NEWS.getNewsPostInstance(currentMember);
+
+            // stub
+            given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+            // when
+            PostResponseDto responseData = postService.findOne(postId);
+
+            // then
+            assertAll(
+                    () -> assertThat(responseData.getContent()).isEqualTo(post.getContent()),
+                    () -> assertThat(responseData.getImages().size()).isEqualTo(post.getImageList().size()),
+                    () -> assertThat(responseData.getCategories()).isEqualTo(post.getPostCategory().getCategoryList()),
+                    () -> assertThat(((PostNewsResponseDto)responseData).getNewsUrl()).isEqualTo(((NewsPost)post).getNewsUrl())
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("기업 회원이 작성한 게시글 조회")
+    class getCorporatePostTest {
+        @Test
+        @DisplayName("조회한 결과가 존재하지 않는 경우, 오류를 반환한다.")
+        public void throwExceptionByEmptyList() {
+            // given
+            List<PostResponseDto> corporatePosts = new ArrayList<>();
+
+            // stub
+            given(postRepository.findPostsByCorporate()).willReturn(corporatePosts);
+
+            // when - then
+            assertThatThrownBy(() -> postService.getCorporatePost())
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("게시글 조회에 성공한다.")
+        public void successGetCorporatePost() {
+            // given
+            List<PostResponseDto> corporatePosts = getPostResponseList();
+
+            // stub
+            given(postRepository.findPostsByCorporate()).willReturn(corporatePosts);
+
+            // when
+            List<PostResponseDto> resultData = postService.getCorporatePost();
+
+            // then
+            assertThat(resultData).isEqualTo(corporatePosts);
+        }
+    }
+
+    @Nested
+    @DisplayName("동아리 회원이 작성한 게시글 조회")
+    class getClubPostTest {
+        @Test
+        @DisplayName("조회한 결과가 존재하지 않는 경우, 오류를 반환한다.")
+        public void throwExceptionByEmptyList() {
+            // given
+            List<PostResponseDto> clubPosts = new ArrayList<>();
+
+            // stub
+            given(postRepository.findPostsByClub()).willReturn(clubPosts);
+
+            // when - then
+            assertThatThrownBy(() -> postService.getClubPost())
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("게시글 조회에 성공한다.")
+        public void successGetClubPost() {
+            // given
+            List<PostResponseDto> clubPosts = getPostResponseList();
+
+            // stub
+            given(postRepository.findPostsByClub()).willReturn(clubPosts);
+
+            // when
+            List<PostResponseDto> resultData = postService.getClubPost();
+
+            // then
+            assertThat(resultData).isEqualTo(clubPosts);
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 가능한 게시글만을 조회")
+    class findVerifiablePostTest {
+        @Test
+        @DisplayName("조회한 결과가 존재하지 않는 경우, 오류를 반환한다.")
+        public void throwExceptionByEmptyList() {
+            // given
+            List<PostResponseDto> verifiablePosts = new ArrayList<>();
+
+            // stub
+            given(postRepository.findVerifiablePosts()).willReturn(verifiablePosts);
+
+            // when - then
+            assertThatThrownBy(() -> postService.findVerifiablePost())
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("게시글 조회에 성공한다.")
+        public void successFindVerifiablePost() {
+            // given
+            List<PostResponseDto> verifiablePosts = getPostResponseList();
+
+            // stub
+            given(postRepository.findVerifiablePosts()).willReturn(verifiablePosts);
+
+            // when
+            List<PostResponseDto> resultData = postService.findVerifiablePost();
+
+            // then
+            assertThat(resultData).isEqualTo(verifiablePosts);
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 가능한 선행 기록")
+    class makeValidateNormalPostTest {
+        private final Member currentMember = MEMBER_1.getPersonalMemberInstance();
+
+        @Test
+        @DisplayName("선행 기록에 성공한다.")
+        public void successMakeValidateNormalPost() {
+            // given
+            PostNormalCreateDto createDto = getNormalCreateDto();
+
+            // stub
+
+            // when
+            postService.makeValidateNormalPost(createDto, currentMember);
+
+            // then
+            verify(postRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 가능한 기사 게시글 기록")
+    class makeValidateNewsTest {
+        private final Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final String NEWS_ACCESS_URL = "NEWS_ACCESS_URL";
+        private final String IMAGE_ACCESS_URL = "ACCESS_URL";
+
+        @Test
+        @DisplayName("기사 게시글 기록에 성공한다.")
+        public void successMakeValidateNewsPost() {
+            // given
+            PostNewsCreateDto createDto = getNewsCreateDto();
+            PostCrawlingResponseDto responseDto = new PostCrawlingResponseDto(NEWS_ACCESS_URL, IMAGE_ACCESS_URL);
+
+            // stub
+            given(crawlingService.crawlingData(anyString())).willReturn(responseDto);
+
+            // when
+            postService.makeValidateNews(createDto, currentMember);
+
+            // then
+            verify(postRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 불가능한 선행 기록")
+    class makeNormalPostTest {
+        private final Member currentMember = MEMBER_1.getPersonalMemberInstance();
+
+        @Test
+        @DisplayName("선행 기록에 성공한다.")
+        public void successMakeNormalPost() {
+            // given
+            PostNormalCreateDto createDto = getNormalCreateDto();
+
+            // stub
+
+            // when
+            postService.makeNormalPost(createDto, currentMember);
+
+            // then
+            verify(postRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 인증")
+    class checkPostValidationTest {
+        private final Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final long errorId = -1;
+        private final long postId = 1;
+
+        @Test
+        @DisplayName("유효하지 않은 PK값이 입력된 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidId() {
+            // given
+
+            // stub
+            given(postRepository.findById(errorId)).willThrow(PostNotFoundException.class);
+
+            // when - then
+            assertThatThrownBy(() -> postService.checkPostValidation(errorId))
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("게시글의 상태가 유효하지 않은 경우, 오류를 반환한다.")
+        public void throwExceptionByPostStatus() {
+            // given
+            Post post = POST_NOT_VERIFIABLE.getPostInstance(currentMember);
+
+            // stub
+            given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+            // when - then
+            assertThatThrownBy(() -> postService.checkPostValidation(postId))
+                    .isInstanceOf(PostVerifyException.class);
+        }
+
+        @Test
+        @DisplayName("게시글 인증에 성공한다.")
+        public void successCheckPostValidation() {
+            // given
+            Post post = POST_VERIFIABLE.getPostInstance(currentMember);
+
+            // stub
+            given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+            // when
+            postService.checkPostValidation(postId);
+
+            // then
+            verify(postRepository).findById(postId);
+        }
+    }
+
+    @Nested
+    @DisplayName("기사 게시글 수정")
+    class editNewsPostTest {
+        private static final Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private static final long errorId = -1;
+        private static final long postId = 1;
+
+        @Test
+        @DisplayName("유효하지 않은 PK값이 입력된 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidId() {
+            // given
+            PostNewsEditDto editDto = getNewsEditDto();
+
+            // stub
+            given(postRepository.findById(errorId)).willThrow(PostNotFoundException.class);
+
+            // when - then
+            assertThatThrownBy(() -> postService.editNewsPost(editDto, currentMember, errorId))
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("기사 게시글 수정에 성공한다.")
+        public void successEditNewsPost() {
+            // given
+            PostNewsEditDto editDto = getNewsEditDto();
+            Post post = POST_NEWS.getNewsPostInstance(currentMember);
+
+            // stub
+            given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+            // when
+            postService.editNewsPost(editDto, currentMember, postId);
+
+            // then
+            verify(postRepository).findById(postId);
+        }
+    }
+
+    @Nested
+    @DisplayName("일반 게시글 수정")
+    class editNormalPostTest {
+        private static final Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private static final long errorId = -1;
+        private static final long postId = 1;
+
+        @Test
+        @DisplayName("유효하지 않은 PK값이 입력된 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidId() {
+            // given
+            PostEditDto editDto = getNormalEditDto();
+
+            // stub
+            given(postRepository.findById(errorId)).willThrow(PostNotFoundException.class);
+
+            // when - then
+            assertThatThrownBy(() -> postService.editNormalPost(editDto, currentMember, errorId))
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("기사 게시글 수정에 성공한다.")
+        public void successEditNormalPost() {
+            // given
+            PostEditDto editDto = getNormalEditDto();
+            Post post = POST_VERIFIABLE.getPostInstance(currentMember);
+
+            // stub
+            given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+            // when
+            postService.editNormalPost(editDto, currentMember, postId);
+
+            // then
+            verify(postRepository).findById(postId);
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 삭제")
+    class deletePostTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static long errorId = -1;
+        private final static long postId = 1;
+
+        @Test
+        @DisplayName("유효하지 않은 PK값이 입력된 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidId() {
+            // given
+
+            // stub
+            given(postRepository.findById(errorId)).willThrow(PostNotFoundException.class);
+
+            // when - then
+            assertThatThrownBy(() -> postService.deletePost(currentMember, errorId));
+        }
+
+        @Test
+        @DisplayName("게시글 삭제에 성공한다.")
+        public void successDeletePost() {
+            // given
+            Post post = POST_VERIFIABLE.getPostInstance(currentMember);
+
+            // stub
+            given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+            // when
+            postService.deletePost(currentMember, postId);
+
+            // then
+            verify(postRepository).findById(postId);
+        }
+    }
+
+    private List<PostResponseDto> getPostResponseList() {
+        Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        List<Post> posts = new ArrayList<>();
+
+        posts.add(POST_VERIFIABLE.getPostInstance(currentMember));
+        posts.add(POST_NOT_VERIFIABLE.getPostInstance(currentMember));
+        posts.add(POST_NEWS.getPostInstance(currentMember));
+
+        return posts.stream().map(PostResponseDto::new).toList();
+    }
+
+    private PostNormalCreateDto getNormalCreateDto() {
+        PostFactory postFactory = POST_VERIFIABLE;
+        List<MultipartFile> files = getFiles();
+        List<String> categories = getCategories();
+
+        return new PostNormalCreateDto(postFactory.getContent(), postFactory.getYear(),
+                postFactory.getMonth(), postFactory.getDate(), files, categories);
+    }
+
+    private PostNewsCreateDto getNewsCreateDto() {
+        PostFactory postFactory = POST_NEWS;
+        List<String> categories = getCategories();
+
+        return new PostNewsCreateDto(postFactory.getNewsUrl(), postFactory.getYear(),
+                postFactory.getMonth(), postFactory.getDate(), categories);
+    }
+
+    private PostEditDto getNormalEditDto() {
+        PostFactory postFactory = POST_NOT_VERIFIABLE;
+        List<MultipartFile> files = getFiles();
+        List<String> categories = getCategories();
+
+        return new PostEditDto(postFactory.getContent(), postFactory.getYear(),
+                postFactory.getMonth(), postFactory.getDate(), categories, files);
+    }
+
+    private PostNewsEditDto getNewsEditDto() {
+        PostFactory postFactory = POST_NEWS;
+        List<String> categories = getCategories();
+
+        return new PostNewsEditDto(postFactory.getNewsUrl(), postFactory.getYear(),
+                postFactory.getMonth(), postFactory.getDate(), categories);
+    }
+
+    private List<MultipartFile> getFiles() {
+        List<MultipartFile> files = new ArrayList<>();
+
+        files.add(new MockMultipartFile("file.jpeg", "IMAGE_NAME_1.jpeg", "multipart/form-data", new byte[]{}));
+        files.add(new MockMultipartFile("file.jpeg", "IMAGE_NAME_2.jpeg", "multipart/form-data", new byte[]{}));
+        files.add(new MockMultipartFile("file.jpeg", "IMAGE_NAME_3.jpeg", "multipart/form-data", new byte[]{}));
+
+        return files;
+    }
+
+    private List<String> getCategories() {
+        List<String> categories = new ArrayList<>();
+
+        categories.add(CATEGORY_VALUE_1.getCategoryName());
+        categories.add(CATEGORY_VALUE_2.getCategoryName());
+
+        return categories;
+    }
+}


### PR DESCRIPTION
- Post 도메인과 관련하여 리팩터링을 수행하였습니다.
    - 일급 컬렉션을 활용한 역할 분리
    - Category를 관리하기 위한 Enum 클래스 활용
    - Service 분리
    - 동적 쿼리 작성을 위한 QueryDsl 활용
    - 테스트 코드 추가