### PR TITLE
[Refactor] 응원 관련 도메인 변경

### DIFF
--- a/precending/src/main/java/umc/precending/controller/cheer/CheerController.java
+++ b/precending/src/main/java/umc/precending/controller/cheer/CheerController.java
@@ -1,0 +1,101 @@
+package umc.precending.controller.cheer;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import umc.precending.domain.member.Member;
+import umc.precending.dto.cheer.CheerResponseDto;
+import umc.precending.response.Response;
+import umc.precending.service.cheer.CheerService;
+import umc.precending.service.member.MemberFindService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "응원 API", description = "개인 회원이 기업이나 동아리를 응원하는 로직을 수행하기 위한 Controller입니다.")
+public class CheerController {
+    private final MemberFindService memberFindService;
+    private final CheerService cheerService;
+
+    @GetMapping("/cheers/corporate")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "GET", summary = "사용자가 응원한 기업 조회", description = "사용자가 응원한 기업 회원들을 조회하는 API")
+    public Response getCheeredCorporate() {
+        Member findMember = getMember();
+        List<String> responseData = cheerService.getCheeringCorporate(findMember);
+
+        return Response.success(responseData);
+    }
+
+    @GetMapping("/cheers/club")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "GET", summary = "사용자가 응원한 동아리 조회", description = "사용자가 응원한 동아리 회원들을 조회하는 API")
+    public Response getCheeredClub() {
+        Member findMember = getMember();
+        List<String> responseData = cheerService.getCheeringClub(findMember);
+
+        return Response.success(responseData);
+    }
+
+    @GetMapping("/cheers/top/corporate")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "GET", summary = "가장 많이 응원받은 기업 조회 - TOP5", description = "사용자들에게 가장 많은 응원을 받은 기업들을 조회하는 API")
+    public Response getMostCorporate() {
+        Member findMember = getMember();
+        List<CheerResponseDto> responseData = cheerService.getMostCorporateMember(findMember);
+
+        return Response.success(responseData);
+    }
+
+    @GetMapping("/cheers/top/club")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "GET", summary = "가장 많이 응원받은 동아리 조회 - TOP5", description = "사용자들에게 가장 많은 응원을 받은 동아리를 조회하는 API")
+    public Response getMostClub() {
+        Member findMember = getMember();
+        List<CheerResponseDto> responseData = cheerService.getMostClubMember(findMember);
+
+        return Response.success(responseData);
+    }
+
+    @PostMapping("/cheers/corporate/{id}")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(method = "POST", summary = "기업 응원", description = "특정 기업을 응원하기 위한 API")
+    public void cheerCorporate(@PathVariable Long id) {
+        Member findMember = getMember();
+        cheerService.cheerCorporateMember(findMember, id);
+    }
+
+    @PostMapping("/cheers/club/{id}")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(method = "POST", summary = "동아리 응원", description = "특정 동아리를 응원하기 위한 API")
+    public void cheerClub(@PathVariable Long id) {
+        Member findMember = getMember();
+        cheerService.cheerClubMember(findMember, id);
+    }
+
+    @DeleteMapping("/cheers/corporate/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "DELETE", summary = "기업 응원 취소", description = "특정 기업에 대한 응원을 취소하는 API")
+    public void disposeCorporateCheer(@PathVariable Long id) {
+        Member findMember = getMember();
+
+        cheerService.disposeCorporateCheer(findMember, id);
+    }
+
+    @DeleteMapping("/cheers/club/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(method = "DELETE", summary = "동아리 응원 취소", description = "특정 동아리에 대한 응원을 취소하는 API")
+    public void disposeClubCheer(@PathVariable Long id) {
+        Member findMember = getMember();
+
+        cheerService.disposeClubCheer(findMember, id);
+    }
+
+    private Member getMember() {
+        return memberFindService.findCurrentMember();
+    }
+}

--- a/precending/src/main/java/umc/precending/domain/cheer/Cheer.java
+++ b/precending/src/main/java/umc/precending/domain/cheer/Cheer.java
@@ -1,0 +1,36 @@
+package umc.precending.domain.cheer;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import umc.precending.domain.base.BaseEntity;
+import umc.precending.domain.member.Member;
+
+@Entity
+@Getter
+@Table(name = "CHEER")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cheer extends BaseEntity {
+    @Id
+    @Column(name = "cheer_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    @JoinColumn(name = "personal_member")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member personalMember;
+
+    @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_member")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member organizationMember;
+
+    public Cheer(Member personalMember, Member organizationMember) {
+        this.personalMember = personalMember;
+        this.organizationMember = organizationMember;
+    }
+}

--- a/precending/src/main/java/umc/precending/dto/cheer/CheerResponseDto.java
+++ b/precending/src/main/java/umc/precending/dto/cheer/CheerResponseDto.java
@@ -1,0 +1,16 @@
+package umc.precending.dto.cheer;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class CheerResponseDto {
+    private String name;
+    private int score;
+
+    @QueryProjection
+    public CheerResponseDto(String name, int score) {
+        this.name = name;
+        this.score = score;
+    }
+}

--- a/precending/src/main/java/umc/precending/dto/image/ImageDto.java
+++ b/precending/src/main/java/umc/precending/dto/image/ImageDto.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.precending.domain.image.Image;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ImageDto {
     private String originalName;
     private String storedName;
     private String accessUrl;
 
-    public static <T extends Image> ImageDto toDto(T image) {
+    public static ImageDto toDto(Image image) {
         return new ImageDto(image.getOriginalName(), image.getStoredName(), image.getAccessUrl());
     }
 }

--- a/precending/src/main/java/umc/precending/exception/cheer/CheerListEmptyException.java
+++ b/precending/src/main/java/umc/precending/exception/cheer/CheerListEmptyException.java
@@ -1,0 +1,4 @@
+package umc.precending.exception.cheer;
+
+public class CheerListEmptyException extends RuntimeException {
+}

--- a/precending/src/main/java/umc/precending/exception/cheer/CheerMemberNotFoundException.java
+++ b/precending/src/main/java/umc/precending/exception/cheer/CheerMemberNotFoundException.java
@@ -1,0 +1,4 @@
+package umc.precending.exception.cheer;
+
+public class CheerMemberNotFoundException extends RuntimeException {
+}

--- a/precending/src/main/java/umc/precending/exception/cheer/CheerNotFoundException.java
+++ b/precending/src/main/java/umc/precending/exception/cheer/CheerNotFoundException.java
@@ -1,0 +1,4 @@
+package umc.precending.exception.cheer;
+
+public class CheerNotFoundException extends RuntimeException {
+}

--- a/precending/src/main/java/umc/precending/repository/cheer/CheerRepository.java
+++ b/precending/src/main/java/umc/precending/repository/cheer/CheerRepository.java
@@ -1,0 +1,8 @@
+package umc.precending.repository.cheer;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.precending.domain.cheer.Cheer;
+import umc.precending.repository.cheer.infra.CheerQueryRepository;
+
+public interface CheerRepository extends JpaRepository<Cheer, Long>, CheerQueryRepository {
+}

--- a/precending/src/main/java/umc/precending/repository/cheer/infra/CheerQueryRepository.java
+++ b/precending/src/main/java/umc/precending/repository/cheer/infra/CheerQueryRepository.java
@@ -1,0 +1,12 @@
+package umc.precending.repository.cheer.infra;
+
+import umc.precending.domain.member.Authority;
+import umc.precending.domain.member.Member;
+import umc.precending.dto.cheer.CheerResponseDto;
+
+import java.util.List;
+
+public interface CheerQueryRepository {
+    List<String> findCheeringMemberList(Member member, Authority authority);
+    List<CheerResponseDto> findTopCheeringMember(Authority authority);
+}

--- a/precending/src/main/java/umc/precending/repository/cheer/infra/CheerQueryRepositoryImpl.java
+++ b/precending/src/main/java/umc/precending/repository/cheer/infra/CheerQueryRepositoryImpl.java
@@ -1,0 +1,53 @@
+package umc.precending.repository.cheer.infra;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import umc.precending.domain.member.*;
+import umc.precending.dto.cheer.CheerResponseDto;
+import umc.precending.dto.cheer.QCheerResponseDto;
+
+import java.util.List;
+
+import static umc.precending.domain.cheer.QCheer.*;
+import static umc.precending.domain.member.QClub.*;
+import static umc.precending.domain.member.QCorporate.*;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CheerQueryRepositoryImpl implements CheerQueryRepository {
+    private static final int MAX_PAGE = 5;
+    private final JPAQueryFactory jpaQueryFactory;
+    @Override
+    public List<String> findCheeringMemberList(Member member, Authority authority) {
+        return jpaQueryFactory
+                .selectDistinct(cheer.organizationMember.name)
+                .where(cheer.personalMember.username.eq(member.getUsername())
+                        .and(cheer.organizationMember.authority.eq(authority)))
+                .orderBy(cheer.organizationMember.name.asc())
+                .limit(MAX_PAGE)
+                .fetch();
+    }
+
+    @Override
+    public List<CheerResponseDto> findTopCheeringMember(Authority authority) {
+        return jpaQueryFactory
+                .select(getResponseType(authority))
+                .from(cheer)
+                .where(cheer.organizationMember.authority.eq(authority))
+                .orderBy(getOrderCondition(authority))
+                .limit(MAX_PAGE)
+                .fetch();
+    }
+
+    private QCheerResponseDto getResponseType(Authority authority) {
+        if(authority.equals(Authority.ROLE_CORPORATE)) return new QCheerResponseDto(corporate.name, corporate.score);
+        return new QCheerResponseDto(club.name, club.score);
+    }
+
+    private OrderSpecifier<?> getOrderCondition(Authority authority) {
+        if(authority.equals(Authority.ROLE_CORPORATE)) return corporate.score.desc();
+        return club.score.desc();
+    }
+}

--- a/precending/src/main/java/umc/precending/service/cheer/CheerService.java
+++ b/precending/src/main/java/umc/precending/service/cheer/CheerService.java
@@ -1,0 +1,154 @@
+package umc.precending.service.cheer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.precending.domain.cheer.Cheer;
+import umc.precending.domain.member.Authority;
+import umc.precending.domain.member.Club;
+import umc.precending.domain.member.Corporate;
+import umc.precending.domain.member.Member;
+import umc.precending.dto.cheer.CheerResponseDto;
+import umc.precending.exception.cheer.CheerListEmptyException;
+import umc.precending.exception.cheer.CheerMemberNotFoundException;
+import umc.precending.exception.cheer.CheerNotFoundException;
+import umc.precending.exception.member.MemberRoleException;
+import umc.precending.repository.cheer.CheerRepository;
+import umc.precending.service.member.MemberFindService;
+
+import java.util.List;
+
+import static umc.precending.domain.member.Authority.*;
+
+@Service
+@RequiredArgsConstructor
+public class CheerService {
+    private final MemberFindService memberFindService;
+    private final CheerRepository cheerRepository;
+
+    @Transactional(readOnly = true)
+    public List<String> getCheeringCorporate(Member member) {
+        checkMemberValidation(member, ROLE_PERSON);
+
+        List<String> corporateList = cheerRepository.findCheeringMemberList(member, ROLE_CORPORATE);
+        if(corporateList.isEmpty()) throw new CheerMemberNotFoundException();
+
+        return corporateList;
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getCheeringClub(Member member) {
+        checkMemberValidation(member, ROLE_PERSON);
+
+        List<String> clubList = cheerRepository.findCheeringMemberList(member, ROLE_CLUB);
+        if(clubList.isEmpty()) throw new CheerMemberNotFoundException();
+
+        return clubList;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CheerResponseDto> getMostCorporateMember(Member member) {
+        List<CheerResponseDto> topMemberList = cheerRepository.findTopCheeringMember(ROLE_CORPORATE);
+        if(topMemberList.isEmpty()) throw new CheerListEmptyException();
+
+        return topMemberList;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CheerResponseDto> getMostClubMember(Member member) {
+        List<CheerResponseDto> topMemberList = cheerRepository.findTopCheeringMember(ROLE_CLUB);
+        if(topMemberList.isEmpty()) throw new CheerListEmptyException();
+
+        return topMemberList;
+    }
+
+    @Transactional
+    public void cheerCorporateMember(Member member, Long corporateId) {
+        checkMemberValidation(member, ROLE_PERSON);
+
+        Member findMember = findMember(corporateId);
+        checkMemberValidation(findMember, ROLE_CORPORATE);
+
+        Cheer cheer = getCheerInstance(member, findMember);
+        cheerOrganization(findMember);
+
+        cheerRepository.save(cheer);
+    }
+
+    @Transactional
+    public void cheerClubMember(Member member, Long clubId) {
+        checkMemberValidation(member, ROLE_PERSON);
+
+        Member findMember = findMember(clubId);
+        checkMemberValidation(findMember, ROLE_CLUB);
+
+        Cheer cheer = getCheerInstance(member, findMember);
+        cheerOrganization(findMember);
+
+        cheerRepository.save(cheer);
+    }
+
+    @Transactional
+    public void disposeCorporateCheer(Member member, Long cheerId) {
+        checkMemberValidation(member, ROLE_PERSON);
+
+        Cheer findCheer = findCheerById(cheerId);
+
+        checkCheerAndMemberValidation(findCheer, member, ROLE_CORPORATE);
+        disposeCheer(findCheer.getOrganizationMember());
+
+        cheerRepository.delete(findCheer);
+    }
+
+    @Transactional
+    public void disposeClubCheer(Member member, Long cheerId) {
+        checkMemberValidation(member, ROLE_PERSON);
+
+        Cheer findCheer = findCheerById(cheerId);
+
+        checkCheerAndMemberValidation(findCheer, member, ROLE_CLUB);
+        disposeCheer(findCheer.getOrganizationMember());
+
+        cheerRepository.delete(findCheer);
+    }
+
+    private void checkMemberValidation(Member member, Authority authority) {
+        if(!member.getAuthority().equals(authority)) throw new MemberRoleException();
+    }
+
+    private void checkCheerAndMemberValidation(Cheer cheer, Member member, Authority authority) {
+        if(!cheer.getPersonalMember().getUsername().equals(member.getUsername()))
+            throw new MemberRoleException();
+        checkMemberValidation(cheer.getOrganizationMember(), authority);
+    }
+
+    private Member findMember(Long id) {
+        return memberFindService.findMemberById(id);
+    }
+
+    private Cheer getCheerInstance(Member personalMember, Member organizationMember) {
+        return new Cheer(personalMember, organizationMember);
+    }
+
+    private <T extends Member> void cheerOrganization(T organization) {
+        if(organization instanceof Corporate) {
+            ((Corporate)organization).increaseScore();
+            return;
+        }
+
+        ((Club)organization).increaseScore();
+    }
+
+    private Cheer findCheerById(Long cheerId) {
+        return cheerRepository.findById(cheerId).orElseThrow(CheerNotFoundException::new);
+    }
+
+    private <T extends Member> void disposeCheer(T organization) {
+        if(organization instanceof Corporate) {
+            ((Corporate)organization).decreaseScore();
+            return;
+        }
+
+        ((Club)organization).decreaseScore();
+    }
+}

--- a/precending/src/test/java/umc/precending/controller/CheerControllerTest.java
+++ b/precending/src/test/java/umc/precending/controller/CheerControllerTest.java
@@ -1,0 +1,237 @@
+package umc.precending.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import umc.precending.controller.cheer.CheerController;
+import umc.precending.domain.member.Member;
+import umc.precending.dto.cheer.CheerResponseDto;
+import umc.precending.service.cheer.CheerService;
+import umc.precending.service.member.MemberFindService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static umc.precending.factory.MemberFactory.MEMBER_1;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cheer [Controller Layer] -> CheerController 테스트")
+public class CheerControllerTest {
+    @Mock
+    private MemberFindService memberFindService;
+
+    @Mock
+    private CheerService cheerService;
+
+    @InjectMocks
+    private CheerController cheerController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void initTest() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(cheerController)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("사용자가 응원한 기업 조회 API [GET /api/cheers/corporate]")
+    class getCheeredCorporateTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static String BASE_URL = "/api/cheers/corporate";
+
+        @Test
+        @DisplayName("응원한 기업 조회에 성공한다.")
+        public void successGetCheeredCorporate() throws Exception {
+            // given
+            List<String> responseData = new ArrayList<>();
+
+            // stub
+            given(memberFindService.findCurrentMember()).willReturn(currentMember);
+            given(cheerService.getCheeringCorporate(currentMember)).willReturn(responseData);
+
+            // when
+            mockMvc.perform(get(BASE_URL))
+                    .andExpect(status().isOk());
+
+            // then
+            verify(cheerService).getCheeringCorporate(currentMember);
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자가 응원한 동아리 조회 API [GET /api/cheers/club]")
+    class getCheeredClubTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static String BASE_URL = "/api/cheers/club";
+        @Test
+        @DisplayName("응원한 동아리 조회에 성공한다.")
+        public void successGetCheeredClub() throws Exception {
+            // given
+            List<String> responseData = new ArrayList<>();
+
+            // stub
+            given(memberFindService.findCurrentMember()).willReturn(currentMember);
+            given(cheerService.getCheeringClub(currentMember)).willReturn(responseData);
+
+            // when
+            mockMvc.perform(get(BASE_URL)).andExpect(status().isOk());
+
+            // then
+            verify(cheerService).getCheeringClub(currentMember);
+        }
+    }
+
+    @Nested
+    @DisplayName("가장 많이 응원받은 기업 조회 API [GET /api/cheers/top/corporate]")
+    class getMostCorporateTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static String BASE_URL = "/api/cheers/top/corporate";
+        @Test
+        @DisplayName("가장 많은 응원을 받은 기업 조회에 성공한다.")
+        public void successGetMostCorporate() throws Exception {
+            // given
+            List<CheerResponseDto> responseData = new ArrayList<>();
+
+            // stub
+            given(memberFindService.findCurrentMember()).willReturn(currentMember);
+            given(cheerService.getMostCorporateMember(currentMember)).willReturn(responseData);
+
+            // when
+            mockMvc.perform(get(BASE_URL)).andExpect(status().isOk());
+
+            // then
+            verify(cheerService).getMostCorporateMember(currentMember);
+        }
+    }
+
+    @Nested
+    @DisplayName("가장 많이 응원받은 동아리 조회 API [GET /api//cheers/top/club]")
+    class getMostClubTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static String BASE_URL = "/api//cheers/top/club";
+
+        @Test
+        @DisplayName("가장 많은 응원을 받은 동아리 조회에 성공한다.")
+        public void successGetMostClub() throws Exception {
+            // given
+            List<CheerResponseDto> responseData = new ArrayList<>();
+
+            // stub
+            given(memberFindService.findCurrentMember()).willReturn(currentMember);
+            given(cheerService.getMostClubMember(currentMember)).willReturn(responseData);
+
+            // when
+            mockMvc.perform(get(BASE_URL)).andExpect(status().isOk());
+
+            // then
+            verify(cheerService).getMostClubMember(currentMember);
+        }
+    }
+
+    @Nested
+    @DisplayName("기업 응원 API [POST /api/cheers/corporate/{id}]")
+    class cheerCorporateTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static String BASE_URL = "/api/cheers/corporate/{id}";
+        private final static long corporateId = 1L;
+
+        @Test
+        @DisplayName("기업 응원에 성공한다.")
+        public void successCheerCorporate() throws Exception {
+            // given
+
+            // stub
+            given(memberFindService.findCurrentMember()).willReturn(currentMember);
+            willDoNothing().given(cheerService).cheerCorporateMember(currentMember, corporateId);
+
+            // when
+            mockMvc.perform(post(BASE_URL, corporateId)).andExpect(status().isCreated());
+
+            // then
+            verify(cheerService).cheerCorporateMember(currentMember, corporateId);
+        }
+    }
+
+    @Nested
+    @DisplayName("동아리 응원 API [POST /api/cheers/club/{id}]")
+    class cheerClubTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static String BASE_URL = "/api/cheers/club/{id}";
+        private final static long clubId = 1L;
+
+        @Test
+        @DisplayName("동아리 응원에 성공한다.")
+        public void successCheerClub() throws Exception {
+            // given
+
+            // stub
+            given(memberFindService.findCurrentMember()).willReturn(currentMember);
+            willDoNothing().given(cheerService).cheerClubMember(currentMember, clubId);
+
+            // when
+            mockMvc.perform(post(BASE_URL, clubId)).andExpect(status().isCreated());
+
+            // then
+            verify(cheerService).cheerClubMember(currentMember, clubId);
+        }
+    }
+
+    @Nested
+    @DisplayName("기업 응원 취소 API [DELETE /api/cheers/corporate/{id}]")
+    class disposeCorporateCheerTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static String BASE_URL = "/api/cheers/corporate/{id}";
+        private final static long cheerId = 1L;
+
+        @Test
+        @DisplayName("기업 응원 취소에 성공한다.")
+        public void successDisposeCorporateCheer() throws Exception {
+            // given
+
+            // stub
+            given(memberFindService.findCurrentMember()).willReturn(currentMember);
+            willDoNothing().given(cheerService).disposeCorporateCheer(currentMember, cheerId);
+
+            // when
+            mockMvc.perform(delete(BASE_URL, cheerId)).andExpect(status().isOk());
+
+            // then
+            verify(cheerService).disposeCorporateCheer(currentMember, cheerId);
+        }
+    }
+
+    @Nested
+    @DisplayName("동아리 응원 취소 API [DELETE /api/cheers/club/{id}]")
+    class disposeClubCheerTest {
+        private final static Member currentMember = MEMBER_1.getPersonalMemberInstance();
+        private final static String BASE_URL = "/api/cheers/club/{id}";
+        private final static long cheerId = 1L;
+        @Test
+        @DisplayName("동아리 응원 취소에 성공한다.")
+        public void successDisposeClubCheer() throws Exception {
+            // given
+
+            // stub
+            given(memberFindService.findCurrentMember()).willReturn(currentMember);
+            willDoNothing().given(cheerService).disposeClubCheer(currentMember, cheerId);
+
+            // when
+            mockMvc.perform(delete(BASE_URL, cheerId)).andExpect(status().isOk());
+
+            // then
+            verify(cheerService).disposeClubCheer(currentMember, cheerId);
+        }
+    }
+}

--- a/precending/src/test/java/umc/precending/factory/CheerFactory.java
+++ b/precending/src/test/java/umc/precending/factory/CheerFactory.java
@@ -1,0 +1,10 @@
+package umc.precending.factory;
+
+import umc.precending.domain.cheer.Cheer;
+import umc.precending.domain.member.Member;
+
+public class CheerFactory {
+    public static Cheer getCheerInstance(Member personalMember, Member organizationMember) {
+        return new Cheer(personalMember, organizationMember);
+    }
+}

--- a/precending/src/test/java/umc/precending/service/CheerServiceTest.java
+++ b/precending/src/test/java/umc/precending/service/CheerServiceTest.java
@@ -1,0 +1,523 @@
+package umc.precending.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.precending.domain.cheer.Cheer;
+import umc.precending.domain.member.Member;
+import umc.precending.dto.cheer.CheerResponseDto;
+import umc.precending.exception.cheer.CheerListEmptyException;
+import umc.precending.exception.cheer.CheerMemberNotFoundException;
+import umc.precending.exception.cheer.CheerNotFoundException;
+import umc.precending.exception.member.MemberNotFoundException;
+import umc.precending.exception.member.MemberRoleException;
+import umc.precending.repository.cheer.CheerRepository;
+import umc.precending.service.cheer.CheerService;
+import umc.precending.service.member.MemberFindService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static umc.precending.domain.member.Authority.*;
+import static umc.precending.factory.CheerFactory.*;
+import static umc.precending.factory.MemberFactory.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cheer [Service Layer] -> CheerService 테스트")
+public class CheerServiceTest {
+    @Mock
+    private MemberFindService memberFindService;
+
+    @Mock
+    private CheerRepository cheerRepository;
+
+    @InjectMocks
+    private CheerService cheerService;
+
+    @Nested
+    @DisplayName("현재 응원 중인 기업 조회")
+    class getCheeringCorporateTest {
+        private static final Member personalMember = MEMBER_1.getPersonalMemberInstance();
+        private static final Member corporateMember = MEMBER_1.getCorporateMemberInstance();
+
+        @Test
+        @DisplayName("현재 사용자가 개인 회원이 아닌 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidRole() {
+            // given
+
+            // stub
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.getCheeringCorporate(corporateMember))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("조건에 부합하는 데이터가 존재하지 않는 경우, 오류를 반환한다.")
+        public void throwExceptionByEmptyList() {
+            // given
+            List<String> corporates = new ArrayList<>();
+
+            // stub
+            given(cheerRepository.findCheeringMemberList(personalMember, ROLE_CORPORATE))
+                    .willReturn(corporates);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.getCheeringCorporate(personalMember))
+                    .isInstanceOf(CheerMemberNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("현재 응원 중인 기업을 조회하는 데에 성공한다.")
+        public void successGetCheeringCorporate() {
+            // given
+            List<String> corporates = getResponseList();
+
+            // stub
+            given(cheerRepository.findCheeringMemberList(personalMember, ROLE_CORPORATE))
+                    .willReturn(corporates);
+
+            // when
+            cheerService.getCheeringCorporate(personalMember);
+
+            // then
+            verify(cheerRepository).findCheeringMemberList(personalMember, ROLE_CORPORATE);
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 응원 중인 동아리 조회")
+    class getCheeringClubTest {
+        private static final Member personalMember = MEMBER_1.getPersonalMemberInstance();
+        private static final Member clubMember = MEMBER_1.getClubMemberInstance();
+
+        @Test
+        @DisplayName("현재 사용자가 개인 회원이 아닌 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidRole() {
+            // given
+
+            // stub
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.getCheeringClub(clubMember))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("조건에 부합하는 데이터가 존재하지 않는 경우, 오류를 반환한다.")
+        public void throwExceptionByEmptyList() {
+            // given
+            List<String> clubs = new ArrayList<>();
+
+            // stub
+            given(cheerRepository.findCheeringMemberList(personalMember, ROLE_CLUB))
+                    .willReturn(clubs);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.getCheeringClub(personalMember))
+                    .isInstanceOf(CheerMemberNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("현재 응원 중인 동아리를 조회하는 데에 성공한다.")
+        public void successGetCheeringClub() {
+            // given
+            List<String> clubs = getResponseList();
+
+            // stub
+            given(cheerRepository.findCheeringMemberList(personalMember, ROLE_CLUB))
+                    .willReturn(clubs);
+
+            // when
+            cheerService.getCheeringClub(personalMember);
+
+            // then
+            verify(cheerRepository).findCheeringMemberList(personalMember, ROLE_CLUB);
+        }
+    }
+
+    @Nested
+    @DisplayName("가장 많은 응원을 받고 있는 기업 조회")
+    class getMostCorporateMemberTest {
+        @Test
+        @DisplayName("조건에 부합하는 데이터가 존재하지 않는 경우, 오류를 반환한다.")
+        public void throwExceptionByEmptyList() {
+            // given
+            List<CheerResponseDto> responseData = new ArrayList<>();
+
+            // stub
+            given(cheerRepository.findTopCheeringMember(ROLE_CORPORATE))
+                    .willReturn(responseData);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.getMostCorporateMember(any()))
+                    .isInstanceOf(CheerListEmptyException.class);
+        }
+
+        @Test
+        @DisplayName("가장 많은 응원을 받고 있는 기업을 조회하는 데에 성공한다.")
+        public void successGetMostCorporateMember() {
+            // given
+            List<CheerResponseDto> responseData = getCheerResponseList();
+
+            // stub
+            given(cheerRepository.findTopCheeringMember(ROLE_CORPORATE))
+                    .willReturn(responseData);
+
+            // when
+            cheerService.getMostCorporateMember(any());
+
+            // then
+            verify(cheerRepository).findTopCheeringMember(ROLE_CORPORATE);
+        }
+    }
+
+    @Nested
+    @DisplayName("가장 많은 응원을 받고 있는 동아리 조회")
+    class getMostClubMemberTest {
+        @Test
+        @DisplayName("조건에 부합하는 데이터가 존재하지 않는 경우, 오류를 반환한다.")
+        public void throwExceptionByEmptyList() {
+            // given
+            List<CheerResponseDto> responseData = new ArrayList<>();
+
+            // stub
+            given(cheerRepository.findTopCheeringMember(ROLE_CLUB))
+                    .willReturn(responseData);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.getMostClubMember(any()))
+                    .isInstanceOf(CheerListEmptyException.class);
+        }
+
+        @Test
+        @DisplayName("가장 많은 응원을 받고 있는 동아리를 조회하는 데에 성공한다.")
+        public void successGetMostClubMember() {
+            // given
+            List<CheerResponseDto> responseData = getCheerResponseList();
+
+            // stub
+            given(cheerRepository.findTopCheeringMember(ROLE_CLUB))
+                    .willReturn(responseData);
+
+            // when
+            cheerService.getMostClubMember(any());
+
+            // then
+            verify(cheerRepository).findTopCheeringMember(ROLE_CLUB);
+        }
+    }
+
+    @Nested
+    @DisplayName("기업 회원 응원")
+    class cheerCorporateMemberTest {
+        private final static Member personalMember = MEMBER_1.getPersonalMemberInstance();
+        private final static Member corporateMember = MEMBER_1.getCorporateMemberInstance();
+        private final static long corporateId = 1;
+        private final static long errorId = -1;
+
+        @Test
+        @DisplayName("현재 사용자가 개인 회원이 아닌 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidRole() {
+            // given
+
+            // stub
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.cheerCorporateMember(corporateMember, corporateId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 PK로 요청하였을 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidId() {
+            // given
+
+            // stub
+            willThrow(new MemberNotFoundException())
+                    .given(memberFindService)
+                    .findMemberById(errorId);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.cheerCorporateMember(personalMember, errorId));
+        }
+
+        @Test
+        @DisplayName("응원하는 대상이 기업 회원이 아닌 경우, 오류를 반환한다.")
+        public void throwExceptionByOrganizationRole() {
+            // given
+
+            // stub
+            given(memberFindService.findMemberById(corporateId)).willReturn(personalMember);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.cheerCorporateMember(personalMember, corporateId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("기업 회원을 응원하는데에 성공한다.")
+        public void successCheerCorporateMember() {
+            // given
+
+            // stub
+            given(memberFindService.findMemberById(corporateId)).willReturn(corporateMember);
+
+            // when
+            cheerService.cheerCorporateMember(personalMember, corporateId);
+
+            // then
+            verify(cheerRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("동아리 회원 응원")
+    class cheerClubMemberTest {
+        private final static Member personalMember = MEMBER_1.getPersonalMemberInstance();
+        private final static Member clubMember = MEMBER_1.getClubMemberInstance();
+        private final static long clubId = 1;
+        private final static long errorId = -1;
+
+        @Test
+        @DisplayName("현재 사용자가 개인 회원이 아닌 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidRole() {
+            // given
+
+            // stub
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.cheerCorporateMember(clubMember, clubId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 PK로 요청하였을 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidId() {
+            // given
+
+            // stub
+            willThrow(new MemberNotFoundException())
+                    .given(memberFindService)
+                    .findMemberById(errorId);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.cheerClubMember(personalMember, errorId));
+        }
+
+        @Test
+        @DisplayName("응원하는 대상이 동아리 회원이 아닌 경우, 오류를 반환한다.")
+        public void throwExceptionByOrganizationRole() {
+            // given
+
+            // stub
+            given(memberFindService.findMemberById(clubId)).willReturn(personalMember);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.cheerClubMember(personalMember, clubId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("동아리 회원을 응원하는데에 성공한다.")
+        public void successCheerClubMember() {
+            // given
+
+            // stub
+            given(memberFindService.findMemberById(clubId)).willReturn(clubMember);
+
+            // when
+            cheerService.cheerClubMember(personalMember, clubId);
+
+            // then
+            verify(cheerRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("기업 응원 취소")
+    class disposeCorporateCheerTest {
+        private final static Member personalMember = MEMBER_1.getPersonalMemberInstance();
+        private final static Member corporateMember = MEMBER_2.getCorporateMemberInstance();
+        private final static long cheerId = 1;
+        private final static long errorId = -1;
+
+        @Test
+        @DisplayName("현재 사용자가 개인 회원이 아닌 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidRole() {
+            // given
+
+            // stub
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.disposeCorporateCheer(corporateMember, cheerId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 PK로 요청하였을 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidId() {
+            // given
+
+            // stub
+            willThrow(new CheerNotFoundException())
+                    .given(cheerRepository)
+                    .findById(errorId);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.disposeCorporateCheer(personalMember, errorId))
+                    .isInstanceOf(CheerNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("사용자 정보와 응원 정보가 일치하지 않을 경우 오류를 반환한다.")
+        public void throwExceptionByInvalidMember() {
+            // given
+            Cheer cheer = getCheerInstance(corporateMember, corporateMember);
+
+            // stub
+            given(cheerRepository.findById(cheerId)).willReturn(Optional.of(cheer));
+
+            // when
+            assertThatThrownBy(() -> cheerService.disposeCorporateCheer(personalMember, cheerId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("단체 정보와 응원 정보가 일치하지 않을 경우 오류를 반환한다.")
+        public void throwExceptionByOrganizationRole() {
+            // given
+            Cheer cheer = getCheerInstance(personalMember, personalMember);
+
+            // stub
+            given(cheerRepository.findById(cheerId)).willReturn(Optional.of(cheer));
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.disposeCorporateCheer(personalMember, cheerId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("기업 응원 취소에 성공한다.")
+        public void successDisposeCorporateCheer() {
+            // given
+            Cheer cheer = getCheerInstance(personalMember, corporateMember);
+
+            // stub
+            given(cheerRepository.findById(cheerId)).willReturn(Optional.of(cheer));
+
+            // when
+            cheerService.disposeCorporateCheer(personalMember, cheerId);
+
+            // then
+            verify(cheerRepository).delete(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("동아리 응원 취소")
+    class disposeClubCheerTest {
+        private final static Member personalMember = MEMBER_1.getPersonalMemberInstance();
+        private final static Member clubMember = MEMBER_2.getClubMemberInstance();
+        private final static long cheerId = 1;
+        private final static long errorId = -1;
+
+        @Test
+        @DisplayName("현재 사용자가 개인 회원이 아닌 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidRole() {
+            // given
+
+            // stub
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.disposeCorporateCheer(clubMember, cheerId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 PK로 요청하였을 경우, 오류를 반환한다.")
+        public void throwExceptionByInvalidId() {
+            // given
+
+            // stub
+            willThrow(new CheerNotFoundException())
+                    .given(cheerRepository)
+                    .findById(errorId);
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.disposeClubCheer(personalMember, errorId))
+                    .isInstanceOf(CheerNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("사용자 정보와 응원 정보가 일치하지 않을 경우 오류를 반환한다.")
+        public void throwExceptionByInvalidMember() {
+            // given
+            Cheer cheer = getCheerInstance(clubMember, clubMember);
+
+            // stub
+            given(cheerRepository.findById(cheerId)).willReturn(Optional.of(cheer));
+
+            // when
+            assertThatThrownBy(() -> cheerService.disposeClubCheer(personalMember, cheerId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("단체 정보와 응원 정보가 일치하지 않을 경우 오류를 반환한다.")
+        public void throwExceptionByOrganizationRole() {
+            // given
+            Cheer cheer = getCheerInstance(personalMember, personalMember);
+
+            // stub
+            given(cheerRepository.findById(cheerId)).willReturn(Optional.of(cheer));
+
+            // when - then
+            assertThatThrownBy(() -> cheerService.disposeClubCheer(personalMember, cheerId))
+                    .isInstanceOf(MemberRoleException.class);
+        }
+
+        @Test
+        @DisplayName("동아리 응원 취소에 성공한다.")
+        public void successDisposeClubCheer() {
+            // given
+            Cheer cheer = getCheerInstance(personalMember, clubMember);
+
+            // stub
+            given(cheerRepository.findById(cheerId)).willReturn(Optional.of(cheer));
+
+            // when
+            cheerService.disposeClubCheer(personalMember, cheerId);
+
+            // then
+            verify(cheerRepository).delete(any());
+        }
+    }
+
+    private List<String> getResponseList() {
+        List<String> responseData = new ArrayList<>();
+
+        responseData.add("TEST_1");
+        responseData.add("TEST_2");
+        responseData.add("TEST_3");
+
+        return responseData;
+    }
+
+    private List<CheerResponseDto> getCheerResponseList() {
+        List<CheerResponseDto> responseData = new ArrayList<>();
+
+        responseData.add(new CheerResponseDto("NAME_1", 10));
+        responseData.add(new CheerResponseDto("NAME_2", 20));
+        responseData.add(new CheerResponseDto("NAME_3", 30));
+
+        return responseData;
+    }
+}


### PR DESCRIPTION
- 기존 응원 도메인 변경
    - 기존에는 Person_Club, Person_Corporate 도메인을 통하여 개인 회원 - 단체 회원의 응원 정보를 관리하였으나, 
    중복되는 데이터가 발생한다고 판단하여 Cheer라는 하나의 도메인으로 변경하여 이를 관리하였습니다.
    - 또한 QueryDsl을 통한 동적 쿼리 작성으로 인하여 기존의 코드를 줄일 수 있었습니다.